### PR TITLE
refactor and clean up output from keyring load

### DIFF
--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -852,8 +852,7 @@ class DictConfig(ObjectConfig):
             raise AssertionException('%s: cannot contain setting for both "%s" and "%s"' % (scope, name, keyring_name))
         if secure_value_key:
             try:
-                self.initialize_keyring()
-                value = keyring.get_password(service_name=secure_value_key, username=user_name)
+                value = self.get_value_from_keyring(secure_value_key, user_name)
             except Exception as e:
                 raise AssertionException('%s: Error accessing secure storage: %s' % (scope, e))
         else:
@@ -863,7 +862,7 @@ class DictConfig(ObjectConfig):
                 '%s: No value in secure storage for user "%s", key "%s"' % (scope, user_name, secure_value_key))
         return value
 
-    def initialize_keyring(self):
+    def get_value_from_keyring(self, secure_value_key, user_name):
         logger = logging.getLogger("keyring")
         backend_list = {
             'KWallet': 'keyring.backends.kwallet',
@@ -874,14 +873,16 @@ class DictConfig(ObjectConfig):
         }
 
         for k, v in six.iteritems(backend_list):
-            logger.info('Loading backend: ' + k)
+            logger.debug('Loading backend: ' + k)
             suppress_exceptions(import_module(v))
 
         viable_classes = KeyringBackend.get_viable_backends()
         rings = list(suppress_exceptions(viable_classes, exceptions=TypeError))
         selected = max(rings, default=fail.Keyring(), key=lambda p: p.priority)
         keyring.set_keyring(selected)
-        logger.info("Using viable keyring: " + selected.name)
+
+        logger.info("Using keyring '" + selected.name +  "' to retrieve: " + secure_value_key)
+        return keyring.get_password(service_name=secure_value_key, username=user_name)
 
 class ConfigFileLoader:
     """


### PR DESCRIPTION
Cleans up log output for keyring, leaving the load messages to debug and just printing info regarding which keys are being fetched.  

Also refactored the following:
rename initialize_keyring as get_value_from_keyring
Moved keyring.get method into get_value_from_keyring

Now instead of logging like this
![image](https://user-images.githubusercontent.com/37643772/56601354-802bef80-65c0-11e9-8bff-08ef23d6c580.png)

We see this
![image](https://user-images.githubusercontent.com/37643772/56601375-933ebf80-65c0-11e9-8ab5-16421c0e2a78.png)

