### PR TITLE
Feature flag implementation for standalone build

### DIFF
--- a/tests/fixture/extension-config.yml
+++ b/tests/fixture/extension-config.yml
@@ -1,0 +1,61 @@
+# This is a sample configuration file for a user extension.
+#
+# This file extends the behavior specified in your main configuration file,
+# by adding custom python code to the logic for attribute and group mapping
+# which is specified in the directory_users section.
+#
+# To load your extension file, put the file's relative or absolute path
+# as the value of the extension setting in the directory_users section
+# of your main configuration file.
+
+# (optional) extended_attributes (default value is an empty list)
+# extended_attributes is a list of attribute names whose per-user
+# values are required by your extension in order to function properly.
+# These attributes will be read on a per-user basis, and will be available
+# in the source_attributes dictionary in your after_mapping_hook.  Any
+# of these attributes which don't have a value in the directory entry for
+# a given user will have a Python None value in that user's dictionary.
+extended_attributes:
+  - bc
+  - subco
+
+# (optional) extended_adobe_groups (default value is an empty list)
+# extended_adobe_groups is a list of Adobe-side product configuration
+# and/or user group names, exactly like those found in the groups
+# setting in the main configuration file.  Your after_mapping_hook
+# can add users to any product configuration or user group found here
+# as well as any found in the groups setting, and the effect of the
+# --process-groups argument will treat them exactly as if the
+# extended mapping had been specified as part of the groups setting.
+extended_adobe_groups:
+  - Company 1 Users
+  - Company 2 Users
+
+# (required) after_mapping_hook
+# This is where you specify your Python hook code.  Note the vertical bar
+# after the after_mapping_hook label: this vertical bar is required and
+# denotes that all the following indented lines up to the next blank
+# line are part of a code block.  Do not have blank lines in your code block.
+#
+# after_mapping_hook code executes in a scope containing the following variables:
+#
+#     source_attributes   # in: attributes retrieved from customer directory system (eg 'c', 'givenName')
+#                         # out: N/A
+#     source_groups       # in: customer-side directory groups found for user
+#                         # out: N/A
+#     target_attributes   # in: user's attributes for UMAPI calls as defined by usual rules (eg 'country', 'firstname')
+#                         # out: user's attributes for UMAPI calls as potentially changed by hook code
+#     target_groups       # in: Adobe-side dashboard groups mapped for user by usual rules
+#                         # out: Adobe-side dashboard groups as potentially changed by hook code
+#     hook_storage        # for exclusive use by hook code: initialized to None; persists across per-user calls
+#     logger              # an object of type logging.logger which outputs to the console and/or file log
+#
+after_mapping_hook: |
+  bc = source_attributes.get('bc')
+  subco = source_attributes.get('subco')
+  if bc is not None:
+    target_attributes['country'] = bc[0:2]
+  if subco == 'Company 1':
+    target_groups.add('Company 1 Users')
+  elif subco == 'Company 2':
+    target_groups.add('Company 2 Users')

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import subprocess
+from copy import deepcopy
 
 import six
 import yaml
@@ -97,7 +98,7 @@ class ConfigLoader(object):
 
         # copy instead of direct assignment to preserve original invocation_defaults object
         # otherwise, setting options also sets invocation_defaults (same memory ref)
-        options = self.invocation_defaults.copy()
+        options = deepcopy(self.invocation_defaults)
 
         # get overrides from the main config
         invocation_config = self.main_config.get_dict_config('invocation_defaults', True)
@@ -441,7 +442,7 @@ class ConfigLoader(object):
         """
         Return a dict representing options for RuleProcessor.
         """
-        options = user_sync.rules.RuleProcessor.default_options
+        options = deepcopy(user_sync.rules.RuleProcessor.default_options)
         options.update(self.invocation_options)
 
         # process directory configuration options
@@ -533,7 +534,7 @@ class ConfigLoader(object):
         extension_config = self.get_directory_extension_options()
         options['extension_enabled'] = flags.get_flag('UST_EXTENSION')
         if extension_config and not options['extension_enabled']:
-            self.logger.warn('Extension config functionality is disabled - skipping after-map hook')
+            self.logger.warning('Extension config functionality is disabled - skipping after-map hook')
         elif extension_config:
             after_mapping_hook_text = extension_config.get_string('after_mapping_hook')
             options['after_mapping_hook'] = compile(after_mapping_hook_text, '<per-user after-mapping-hook>', 'exec')

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -31,13 +31,9 @@ import user_sync.helper
 import user_sync.identity_type
 import user_sync.port
 import user_sync.rules
+from user_sync import flags
 from user_sync.error import AssertionException
 
-import keyring
-from importlib import import_module
-from keyring.backends import fail
-from keyring.backend import KeyringBackend
-from keyring.util import suppress_exceptions
 
 class ConfigLoader(object):
     # default values for reading configuration files
@@ -535,9 +531,12 @@ class ConfigLoader(object):
 
         # now get the directory extension, if any
         extension_config = self.get_directory_extension_options()
-        if extension_config:
-            options['extension_enabled'] = True
-            options['after_mapping_hook'] = None
+        options['extension_enabled'] = flags.get_flag('UST_EXTENSION')
+        if extension_config and not options['extension_enabled']:
+            self.logger.warn('Extension config functionality is disabled - skipping after-map hook')
+        elif extension_config:
+            after_mapping_hook_text = extension_config.get_string('after_mapping_hook')
+            options['after_mapping_hook'] = compile(after_mapping_hook_text, '<per-user after-mapping-hook>', 'exec')
             options['extended_attributes'] = extension_config.get_list('extended_attributes')
             # declaration of extended adobe groups: this is needed for two reasons:
             # 1. it allows validation of group names, and matching them to adobe groups
@@ -830,27 +829,36 @@ class DictConfig(ObjectConfig):
                 '%s: No value in secure storage for user "%s", key "%s"' % (scope, user_name, secure_value_key))
         return value
 
-    def get_value_from_keyring(self, secure_value_key, user_name):
-        logger = logging.getLogger("keyring")
-        backend_list = {
-            'KWallet': 'keyring.backends.kwallet',
-            'SecretService': 'keyring.backends.SecretService',
-            'Windows': 'keyring.backends.Windows',
-            'chainer': 'keyring.backends.chainer',
-            'macOS': 'keyring.backends.OS_X',
-        }
+    @staticmethod
+    def get_value_from_keyring(secure_value_key, user_name):
+        import keyring
+        if flags.get_flag('UST_BUILD_EXE'):
+            from importlib import import_module
+            from keyring.backends import fail
+            from keyring.backend import KeyringBackend
+            from keyring.util import suppress_exceptions
 
-        for k, v in six.iteritems(backend_list):
-            logger.debug('Loading backend: ' + k)
-            suppress_exceptions(import_module(v))
+            logger = logging.getLogger("keyring")
+            backend_list = {
+                'KWallet': 'keyring.backends.kwallet',
+                'SecretService': 'keyring.backends.SecretService',
+                'Windows': 'keyring.backends.Windows',
+                'chainer': 'keyring.backends.chainer',
+                'macOS': 'keyring.backends.OS_X',
+            }
 
-        viable_classes = KeyringBackend.get_viable_backends()
-        rings = list(suppress_exceptions(viable_classes, exceptions=TypeError))
-        selected = max(rings, default=fail.Keyring(), key=lambda p: p.priority)
-        keyring.set_keyring(selected)
+            for k, v in six.iteritems(backend_list):
+                logger.debug('Loading backend: ' + k)
+                suppress_exceptions(import_module(v))
 
-        logger.info("Using keyring '" + selected.name +  "' to retrieve: " + secure_value_key)
+            viable_classes = KeyringBackend.get_viable_backends()
+            rings = list(suppress_exceptions(viable_classes, exceptions=TypeError))
+            selected = max(rings, default=fail.Keyring(), key=lambda p: p.priority)
+            keyring.set_keyring(selected)
+
+            logger.info("Using keyring '" + selected.name + "' to retrieve: " + secure_value_key)
         return keyring.get_password(service_name=secure_value_key, username=user_name)
+
 
 class ConfigFileLoader:
     """

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -932,29 +932,49 @@ class ConfigFileLoader:
                           the dictionary if there is not already a value found.
         """
         if filename.startswith('$(') and filename.endswith(')'):
-            raise AssertionException("Shell execution is disabled in this build")
-
-        # it's a pathname to a configuration file to read
-        cls.filepath = os.path.abspath(filename)
-        if not os.path.isfile(cls.filepath):
-            raise AssertionException('No such configuration file: %s' % (cls.filepath,))
-        cls.filename = os.path.split(cls.filepath)[1]
-        cls.dirpath = os.path.dirname(cls.filepath)
-        try:
-            with open(filename, 'rb', 1) as input_file:
-                byte_string = input_file.read()
+            if not flags.get_flag('UST_SHELL_EXEC'):
+                raise AssertionException("Shell execution is disabled in this build")
+            # it's a command line to execute and read standard output
+            dir_end = filename.index(']')
+            if filename.startswith('$([') and dir_end > 0:
+                dir_name = filename[3:dir_end]
+                cmd_name = filename[dir_end + 1:-1]
+            else:
+                dir_name = os.path.abspath(".")
+                cmd_name = filename[3:-1]
+            cls.filepath = cmd_name
+            try:
+                byte_string = subprocess.check_output(cmd_name, cwd=dir_name, shell=True)
                 yml = yaml.safe_load(byte_string.decode(cls.config_encoding, 'strict'))
-        except IOError as e:
-            # if a file operation error occurred while loading the
-            # configuration file, swallow up the exception and re-raise it
-            # as an configuration loader exception.
-            raise AssertionException("Error reading configuration file '%s': %s" % (cls.filepath, e))
-        except UnicodeDecodeError as e:
-            # as above, but in case of encoding errors
-            raise AssertionException("Encoding error in configuration file '%s: %s" % (cls.filepath, e))
-        except yaml.error.MarkedYAMLError as e:
-            # as above, but in case of parse errors
-            raise AssertionException("Error parsing configuration file '%s': %s" % (cls.filepath, e))
+            except subprocess.CalledProcessError as e:
+                raise AssertionException("Error executing process '%s' in dir '%s': %s" % (cmd_name, dir_name, e))
+            except UnicodeDecodeError as e:
+                raise AssertionException('Encoding error in process output: %s' % e)
+            except yaml.error.MarkedYAMLError as e:
+                raise AssertionException('Error parsing process YAML data: %s' % e)
+
+        else:
+            # it's a pathname to a configuration file to read
+            cls.filepath = os.path.abspath(filename)
+            if not os.path.isfile(cls.filepath):
+                raise AssertionException('No such configuration file: %s' % (cls.filepath,))
+            cls.filename = os.path.split(cls.filepath)[1]
+            cls.dirpath = os.path.dirname(cls.filepath)
+            try:
+                with open(filename, 'rb', 1) as input_file:
+                    byte_string = input_file.read()
+                    yml = yaml.safe_load(byte_string.decode(cls.config_encoding, 'strict'))
+            except IOError as e:
+                # if a file operation error occurred while loading the
+                # configuration file, swallow up the exception and re-raise it
+                # as an configuration loader exception.
+                raise AssertionException("Error reading configuration file '%s': %s" % (cls.filepath, e))
+            except UnicodeDecodeError as e:
+                # as above, but in case of encoding errors
+                raise AssertionException("Encoding error in configuration file '%s: %s" % (cls.filepath, e))
+            except yaml.error.MarkedYAMLError as e:
+                # as above, but in case of parse errors
+                raise AssertionException("Error parsing configuration file '%s': %s" % (cls.filepath, e))
 
         # process the content of the dict
         if yml is None:
@@ -962,7 +982,7 @@ class ConfigFileLoader:
             yml = {}
         elif not isinstance(yml, dict):
             # malformed YML files produce a non-dictionary
-            raise AssertionException("Configuration file '%s' does not contain settings" % cls.filepath)
+            raise AssertionException("Configuration file or command '%s' does not contain settings" % cls.filepath)
         for path_key, options in six.iteritems(path_keys):
             cls.key_path = path_key
             keys = path_key.split('/')

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -49,6 +49,7 @@ class RuleProcessor(object):
         'exclude_strays': False,
         'exclude_users': [],
         'extended_attributes': None,
+        'extension_enabled': False,
         'process_groups': False,
         'max_adobe_only_users': 200,
         'new_account_type': user_sync.identity_type.ENTERPRISE_IDENTITY_TYPE,
@@ -388,8 +389,25 @@ class RuleProcessor(object):
                         self.after_mapping_hook_scope['target_groups'].add(adobe_group.get_qualified_name())
 
             # only if there actually is hook code: set up rest of hook scope, invoke hook, update user attributes
-            if options.get('extension_enabled') is not None:
-                self.logger.warn('Extension config functionality is disabled - skipping after-map hook')
+            if options['after_mapping_hook'] is not None:
+                self.after_mapping_hook_scope['source_attributes'] = directory_user['source_attributes'].copy()
+
+                target_attributes = dict()
+                target_attributes['email'] = directory_user.get('email')
+                target_attributes['username'] = directory_user.get('username')
+                target_attributes['domain'] = directory_user.get('domain')
+                target_attributes['firstname'] = directory_user.get('firstname')
+                target_attributes['lastname'] = directory_user.get('lastname')
+                target_attributes['country'] = directory_user.get('country')
+                self.after_mapping_hook_scope['target_attributes'] = target_attributes
+
+                # invoke the customer's hook code
+                self.log_after_mapping_hook_scope(before_call=True)
+                exec(options['after_mapping_hook'], self.after_mapping_hook_scope)
+                self.log_after_mapping_hook_scope(after_call=True)
+
+                # copy modified attributes back to the user object
+                directory_user.update(self.after_mapping_hook_scope['target_attributes'])
 
             for target_group_qualified_name in self.after_mapping_hook_scope['target_groups']:
                 target_group = AdobeGroup.lookup(target_group_qualified_name)


### PR DESCRIPTION
* Do not override automatic Keyring backend selection unless `UST_BUILD_EXE` flag is `True`
* Do not allow extension config execution if extension config is enabled **and** `UST_EXTENSION` flag is `False`
* Do not allow shell execution in config file links if `$()` syntax is used **and** `UST_SHELL_EXEC` is `False`

Additional notes

* `import keyring` statement should only be invoked if credential storage is used.  This is necessary to prevent issues on Linux systems that do not have dbus installed
* I found a bug that persisted option settings when creating multiple `ConfigLoader` objects.  This can have a negative impact on tests.  To fix it we `deepcopy()` the default options from the rule processor.