### PR TITLE
Fixed - Include resources folder in .spec - resolve missing files EXE

### DIFF
--- a/user-sync.spec
+++ b/user-sync.spec
@@ -5,7 +5,10 @@ block_cipher = None
 
 a = Analysis(['user_sync/app.py'],
              binaries=[],
-             datas=[],
+             datas=[( 'user_sync/resources/*.cfg', 'resources' ),
+                    ( 'user_sync/resources/manual_url', 'resources' ),
+                    ( 'user_sync/resources/README.md', 'resources' ),
+                    ( 'user_sync/resources/examples/*', 'resources/examples' )],
              hiddenimports=['win32timezone'],
              hookspath=[],
              runtime_hooks=[],

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -833,13 +833,13 @@ class DictConfig(ObjectConfig):
     @staticmethod
     def get_value_from_keyring(secure_value_key, user_name):
         import keyring
+        logger = logging.getLogger("keyring")
         if flags.get_flag('UST_BUILD_EXE'):
             from importlib import import_module
             from keyring.backends import fail
             from keyring.backend import KeyringBackend
             from keyring.util import suppress_exceptions
 
-            logger = logging.getLogger("keyring")
             backend_list = {
                 'KWallet': 'keyring.backends.kwallet',
                 'SecretService': 'keyring.backends.SecretService',
@@ -857,7 +857,7 @@ class DictConfig(ObjectConfig):
             selected = max(rings, default=fail.Keyring(), key=lambda p: p.priority)
             keyring.set_keyring(selected)
 
-            logger.info("Using keyring '" + selected.name + "' to retrieve: " + secure_value_key)
+        logger.info("Using keyring '" + keyring.get_keyring().name + "' to retrieve: " + secure_value_key)
         return keyring.get_password(service_name=secure_value_key, username=user_name)
 
 


### PR DESCRIPTION
Fixes failure to locate the files stored in resources in the EXE build.  The issues came up when executing the conditional:

if flags.get_flag('UST_BUILD_EXE'):

Resulting in error:
```yaml
2019-05-06 11:13:28 15084 ERROR main - Unhandled exception
Traceback (most recent call last):
  File "user_sync\app.py", line 176, in sync
  File "user_sync\app.py", line 305, in begin_work
  File "user_sync\config.py", line 535, in get_rule_options
  File "user_sync\flags.py", line 71, in get_flag
  File "user_sync\flags.py", line 46, in _init_config
  File "user_sync\flags.py", line 36, in _read_config
  File "lib\site-packages\backports\configparser\__init__.py", line 692, in read
TypeError: 'NoneType' object is not iterable
```

The cfg files were not present in the temporary directory.  Fixed by including all the resources files explicitly in the .spec  in the datas=[ ] section.

Additional:
Added - Move logger in keyring method to work for both pex and exe