### PR TITLE
New Feature --exclude-unmapped-users

### DIFF
--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -330,6 +330,11 @@ invocation_defaults:
   adobe_users: all
   # For argument --connector, the default is 'ldap'.
   connector: ldap
+  # For argument --ignore-outcast-users, the default is False (include all).
+  # If you set this default to True, UST will automatically ignore user creation
+  # on user that is not part of any group.
+  # --include-outcast-users to override the default.
+  ignore_outcast_users: No
   # For argument --process-groups, the default is False (don't process).
   # If you set this default to True, you can supply the argument
   # --no-process-groups to override the default.

--- a/examples/config files - basic/user-sync-config.yml
+++ b/examples/config files - basic/user-sync-config.yml
@@ -330,11 +330,11 @@ invocation_defaults:
   adobe_users: all
   # For argument --connector, the default is 'ldap'.
   connector: ldap
-  # For argument --ignore-outcast-users, the default is False (include all).
-  # If you set this default to True, UST will automatically ignore user creation
-  # on user that is not part of any group.
-  # --include-outcast-users to override the default.
-  ignore_outcast_users: No
+  # For argument --exclude_unmapped_users, the default is False (include all).
+  # If you set this default to True, UST will automatically skip user creation
+  # on user that is not part of any mapped group.
+  # --include-unmapped-users to override the default.
+  exclude_unmapped_users: No
   # For argument --process-groups, the default is False (don't process).
   # If you set this default to True, you can supply the argument
   # --no-process-groups to override the default.

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -125,6 +125,8 @@ def main():
               cls=user_sync.cli.OptionMulti,
               type=list,
               metavar='ldap|okta|csv|adobe_console [path-to-file.csv]')
+@click.option('--ignore-outcast-users/--include-outcast-users', default=None,
+              help='Ignore users that is not part of a group from being sync')
 @click.option('--process-groups/--no-process-groups', default=None,
               help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
                    'the group membership is updated on the Adobe side so that the memberships in mapped '

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -125,8 +125,8 @@ def main():
               cls=user_sync.cli.OptionMulti,
               type=list,
               metavar='ldap|okta|csv|adobe_console [path-to-file.csv]')
-@click.option('--ignore-outcast-users/--include-outcast-users', default=None,
-              help='Ignore users that is not part of a group from being sync')
+@click.option('--exclude-unmapped-users/--include-unmapped-users', default=None,
+              help='Exclude users that is not part of a mapped group from being created on Adobe side')
 @click.option('--process-groups/--no-process-groups', default=None,
               help='if membership in mapped groups differs between the enterprise directory and Adobe sides, '
                    'the group membership is updated on the Adobe side so that the memberships in mapped '

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -51,7 +51,7 @@ class ConfigLoader(object):
         'config_filename': 'user-sync-config.yml',
         'connector': ['ldap'],
         'encoding_name': 'utf8',
-        'ignore_outcast_users': False,
+        'exclude_unmapped_users': False,
         'process_groups': False,
         'strategy': 'sync',
         'test_mode': False,

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -51,6 +51,7 @@ class ConfigLoader(object):
         'config_filename': 'user-sync-config.yml',
         'connector': ['ldap'],
         'encoding_name': 'utf8',
+        'ignore_outcast_users': False,
         'process_groups': False,
         'strategy': 'sync',
         'test_mode': False,

--- a/user_sync/rules.py
+++ b/user_sync/rules.py
@@ -325,8 +325,8 @@ class RuleProcessor(object):
     def will_process_groups(self):
         return self.options['process_groups']
 
-    def will_exclude_outcast_users(self):
-        return self.options['ignore_outcast_users']
+    def will_exclude_unmapped_users(self):
+        return self.options['exclude_unmapped_users']
 
     def get_umapi_info(self, umapi_name):
         umapi_info = self.umapi_info_by_name.get(umapi_name)
@@ -468,7 +468,7 @@ class RuleProcessor(object):
             verb = "Push"
         else:
             verb = "Sync"
-        ignore_outcast_users = self.will_exclude_outcast_users()
+        exclude_unmapped_users = self.will_exclude_unmapped_users()
         # first sync the primary connector, so the users get created in the primary
         if umapi_connectors.get_secondary_connectors():
             self.logger.debug('%sing users to primary umapi...', verb)
@@ -480,7 +480,7 @@ class RuleProcessor(object):
         else:
             primary_adds_by_user_key = self.update_umapi_users_for_connector(umapi_info, umapi_connector)
         for user_key, groups_to_add in six.iteritems(primary_adds_by_user_key):
-            if ignore_outcast_users == True and not groups_to_add:
+            if exclude_unmapped_users == True and not groups_to_add:
                 # If user is not part of any group and ignore outcast is enabled. Do not create user.
                 pass
             else:


### PR DESCRIPTION
This feature will allow UST to exclude users that is not part of a mapped group.

Use Case:

When using --users all, UST will pull everyone from the directory for comparison and sync everyone to the console. When adding this additional argument --users all --exclude-unmapped-users this will only sync users if they are part of the mapped group.

When using --users all --exclude-unmapped-users --adobe-only-users-action delete this will allow UST to compare with the entire directory and delete the users once they are deleted from directory source without syncing unmapped users to the console.