### PR TITLE
Multi director connector part 1 - reading the data from user-sync-config.yml

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -162,3 +162,32 @@ def test_adobe_users_config(tmp_config_files, modify_root_config, cli_args):
     options = config_loader.load_invocation_options()
     assert 'adobe_users' in options
     assert options['adobe_users'] == ['mapped']
+
+# def test_directory_connnector_options(config_files, modify_root_config):
+#     """Load root config file and test for presence of root-level keys"""
+#
+#     d = [{
+#         'id': 'test1',
+#         'type': 'ldap',
+#         'path': 'connector-ldap.yml'
+#         },
+#         {
+#             'id': 'test2',
+#             'type': 'ldap',
+#             'path': 'connector-ldap.yml'
+#         }
+#     ]
+#
+#     modify_root_config(['directory_users', 'connectors', 'multi'], d)
+#
+#     config = ConfigFileLoader.load_root_config(config_files['root_config'])
+#
+#     assert ('multi' in config['directory_users']['connectors'])
+#     assert('test1' in config['directory_users']['connectors']['multi'][0]['id'])
+#     assert ('ldap' in config['directory_users']['connectors']['multi'][0]['type'])
+#     assert ('connector-ldap.yml' in config['directory_users']['connectors']['multi'][0]['path'])
+#     assert ('test2' in config['directory_users']['connectors']['multi'][1]['id'])
+#     assert ('ldap' in config['directory_users']['connectors']['multi'][1]['type'])
+#     assert ('connector-ldap.yml' in config['directory_users']['connectors']['multi'][1]['path'])
+#     assert ('ldap' in config['directory_users']['connectors'])
+#     assert ('connector-ldap.yml') in config['directory_users']['connectors']['ldap']

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -32,7 +32,7 @@ import user_sync.identity_type
 import user_sync.port
 import user_sync.rules
 from user_sync.error import AssertionException
-
+from collections import defaultdict
 
 class ConfigLoader(object):
     # default values for reading configuration files
@@ -128,7 +128,7 @@ class ConfigLoader(object):
         # --connector
         connector_spec = options['connector']
         connector_type = user_sync.helper.normalize_string(connector_spec[0])
-        if connector_type in ["ldap", "okta", "adobe_console"]:
+        if connector_type in ["ldap", "okta", "adobe_console", "multi"]:
             if len(connector_spec) > 1:
                 raise AssertionException('Must not specify a file (%s) with connector type %s' %
                                          (connector_spec[0], connector_type))
@@ -314,6 +314,17 @@ class ConfigLoader(object):
             connectors_config.get_list('csv', True)
             connectors_config.get_list('okta', True)
             connectors_config.get_list('adobe_console', True)
+            multilist = connectors_config.get_list('multi', True)
+            temp_ids=[]
+            dup_dict = defaultdict(list)
+            if multilist is not None:
+                for number, row in enumerate(multilist):
+                    pathinfo = row['path']
+                    if pathinfo not in temp_ids:
+                        temp_ids.append(pathinfo)
+                    else:
+                        raise AssertionException(
+                            "Duplicate path is found")
         return connectors_config
 
     def get_directory_connector_options(self, connector_name):


### PR DESCRIPTION
Currently for Multi Directory Connector, we allow the config.py file to read the multi section of the User Sync Config file. And also added the ensure to ensure it is working as expected.