### PR TITLE
config.py get_credential changes

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,7 @@ def tmp_extension_config(extension_config_file, tmpdir):
     shutil.copy(extension_config_file, tmpfile)
     return tmpfile
 
+
 @pytest.fixture
 def modify_root_config(tmp_config_files):
     (root_config_file, _, _) = tmp_config_files
@@ -193,13 +194,33 @@ def test_shell_exec_flag(tmp_config_files, modify_root_config, cli_args, monkeyp
                 config_loader.get_directory_connector_options(directory_connector.name)
 
 
-def test_get_credential(tmp_config_files):
+def test_get_credential_new_format(tmp_config_files):
     (root_config_file, ldap_config_file, umapi_config_file) = tmp_config_files
-    ldap_config = ConfigFileLoader.load_sub_config(ldap_config_file)
+    credman = CredentialManager()
+    ldap_config = ConfigFileLoader.load_from_yaml(ldap_config_file, {})
     ldap_dict_config = DictConfig('testscope', ldap_config)
-    # if no credentials have been stored then get_credential should return the plaintext value
-    assert ldap_dict_config.get_credential('password', 'username') == 'password'
-    credman = CredentialManager(root_config_file)
-    credman.store()
-    assert ldap_dict_config.get_credential('password', 'username') == 'password'
+    # make sure it still works in plaintext format
+    assert ldap_dict_config.get_credential('password', 'user_sync') == 'password'
+    ldap_config['password'] = {'secure': 'ldap_key'}
+    credman.set('ldap_key', 'test_password')
+    # make sure get_cred still works when passed in a dict with a valid identifier
+    assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'
+    # check for exception to be thrown if there is no value for 'password'
+    ldap_config['password'] = None
+    with pytest.raises(AssertionException):
+        ldap_dict_config.get_credential('password', 'user_sync')
 
+
+def test_get_credential_old_format(tmp_config_files):
+    (root_config_file, ldap_config_file, umapi_config_file) = tmp_config_files
+    credman = CredentialManager()
+    ldap_config = ConfigFileLoader.load_from_yaml(ldap_config_file, {})
+    ldap_dict_config = DictConfig('testscope', ldap_config)
+    # adding the secure key format without removing the plain format should throw an exception
+    ldap_config['secure_password_key'] = 'ldap_secure_identifier'
+    with pytest.raises(AssertionException):
+        ldap_dict_config.get_credential('password', 'user_sync')
+    credman.set('ldap_secure_identifier', 'test_password')
+    # set the plain key to None so get_credential will look for the secure_password_key format
+    ldap_config['password'] = None
+    assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,7 @@ from util import update_dict
 from user_sync.config import ConfigFileLoader, ConfigLoader, DictConfig
 from user_sync import flags
 from user_sync.error import AssertionException
-# this does not work because then it tries to use YAML from ruamel.yaml which has no safe_load method...
-# from user_sync.credentials import *
+from user_sync.credentials import CredentialConfig, CredentialManager
 
 
 def load_ldap_config_options(args):
@@ -194,5 +193,13 @@ def test_shell_exec_flag(tmp_config_files, modify_root_config, cli_args, monkeyp
                 config_loader.get_directory_connector_options(directory_connector.name)
 
 
-# def test_get_credential(tmp_config_files):
-#     (root_config_file, ldap_config_file, umapi_config_file) = tmp_config_files
+def test_get_credential(tmp_config_files):
+    (root_config_file, ldap_config_file, umapi_config_file) = tmp_config_files
+    ldap_config = ConfigFileLoader.load_sub_config(ldap_config_file)
+    ldap_dict_config = DictConfig('testscope', ldap_config)
+    # if no credentials have been stored then get_credential should return the plaintext value
+    assert ldap_dict_config.get_credential('password', 'username') == 'password'
+    credman = CredentialManager(root_config_file)
+    credman.store()
+    assert ldap_dict_config.get_credential('password', 'username') == 'password'
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,6 +205,10 @@ def test_get_credential_new_format(tmp_config_files):
     credman.set('ldap_key', 'test_password')
     # make sure get_cred still works when passed in a dict with a valid identifier
     assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'
+    # if the identifier is invalid it should throw an exception
+    ldap_config['password'] = {'secure': 'invalid_identifier'}
+    with pytest.raises(AssertionException):
+        ldap_dict_config.get_credential('password', 'user_sync')
     # check for exception to be thrown if there is no value for 'password'
     ldap_config['password'] = None
     with pytest.raises(AssertionException):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,8 @@ from util import update_dict
 from user_sync.config import ConfigFileLoader, ConfigLoader, DictConfig
 from user_sync import flags
 from user_sync.error import AssertionException
+# this does not work because then it tries to use YAML from ruamel.yaml which has no safe_load method...
+# from user_sync.credentials import *
 
 
 def load_ldap_config_options(args):
@@ -190,3 +192,7 @@ def test_shell_exec_flag(tmp_config_files, modify_root_config, cli_args, monkeyp
             directory_connector = DirectoryConnector(directory_connector_module)
             with pytest.raises(AssertionException):
                 config_loader.get_directory_connector_options(directory_connector.name)
+
+
+# def test_get_credential(tmp_config_files):
+#     (root_config_file, ldap_config_file, umapi_config_file) = tmp_config_files

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -96,19 +96,19 @@ def test_retrieve_revert_ldap_invalid(tmp_config_files):
 def test_retrieve_revert_umapi_valid(tmp_config_files):
     (_, _, umapi_config_file) = tmp_config_files
     umapi = UmapiCredentialConfig(umapi_config_file)
-    # Using the org_id for assertions. The rest can be added in later if deemed necessary
-    assert not umapi.parse_secure_key(umapi.get_nested_key(['enterprise', 'org_id']))
-    unsecured_org_id = umapi.get_nested_key(['enterprise', 'org_id'])
+    # Using the api_key for assertions. The rest can be added in later if deemed necessary
+    assert not umapi.parse_secure_key(umapi.get_nested_key(['enterprise', 'api_key']))
+    unsecured_api_key = umapi.get_nested_key(['enterprise', 'api_key'])
     umapi.store()
     with open(umapi_config_file) as f:
         data = yaml.load(f)
-        assert umapi.parse_secure_key(data['enterprise']['org_id'])
+        assert umapi.parse_secure_key(data['enterprise']['api_key'])
     retrieved_key_dict = umapi.retrieve()
-    assert retrieved_key_dict['enterprise']['org_id'] == unsecured_org_id
+    assert retrieved_key_dict['enterprise']['api_key'] == unsecured_api_key
     umapi.revert()
     with open(umapi_config_file) as f:
         data = yaml.load(f)
-        assert data['enterprise']['org_id'] == unsecured_org_id
+        assert data['enterprise']['api_key'] == unsecured_api_key
 
 
 def test_credman_retrieve_revert_valid(tmp_config_files):
@@ -119,25 +119,25 @@ def test_credman_retrieve_revert_valid(tmp_config_files):
         plaintext_ldap_password = data['password']
     with open(umapi_config_file) as f:
         data = yaml.load(f)
-        plaintext_umapi_org_id = data['enterprise']['org_id']
+        plaintext_umapi_api_key = data['enterprise']['api_key']
     credman.store()
     retrieved_creds = credman.retrieve()
     assert retrieved_creds['password'] == plaintext_ldap_password
-    assert retrieved_creds['enterprise']['org_id'] == plaintext_umapi_org_id
+    assert retrieved_creds['enterprise']['api_key'] == plaintext_umapi_api_key
     # make sure the config files are still in secure format
     with open(ldap_config_file) as f:
         data = yaml.load(f)
         assert data['password'] != plaintext_ldap_password
     with open(umapi_config_file) as f:
         data = yaml.load(f)
-        assert data['enterprise']['org_id'] != plaintext_umapi_org_id
+        assert data['enterprise']['api_key'] != plaintext_umapi_api_key
     credman.revert()
     with open(ldap_config_file) as f:
         data = yaml.load(f)
         assert data['password'] == plaintext_ldap_password
     with open(umapi_config_file) as f:
         data = yaml.load(f)
-        assert data['enterprise']['org_id'] == plaintext_umapi_org_id
+        assert data['enterprise']['api_key'] == plaintext_umapi_api_key
 
 
 def test_credman_retrieve_revert_invalid(tmp_config_files):

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -409,9 +409,9 @@ def retrieve(config_filename):
     try:
         credential_manager = CredentialManager(config_filename)
         retrieved_creds = credential_manager.retrieve()
-        for k,v in retrieved_creds.items():
-            if k[v] is not None:
-                click.echo("The following values were stored securely: '{0}'".format(k))
+        for k, v in retrieved_creds.items():
+            if v is not None:
+                click.echo('"{}":"{}"').format(k, v)
     except AssertionException as e:
         click.echo(str(e))
 

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -409,14 +409,12 @@ def retrieve(config_filename):
     try:
         credential_manager = CredentialManager(config_filename)
         retrieved_creds = credential_manager.retrieve()
-        for k, v in retrieved_creds.items():
-            if v is not None:
-                click.echo('"{}":"{}"').format(k, v)
+        # echo the identifier:value pairs to the console
     except AssertionException as e:
         click.echo(str(e))
 
 
-@credentials.command(help="Will return configuration file to unsecured state and replace all secrure values with "
+@credentials.command(help="Will return configuration file to unsecured state and replace all secure values with "
                           "plain text values.")
 @click.option('-c', '--config-filename',
               help="path to your main configuration file",
@@ -441,7 +439,7 @@ def revert(config_filename):
         click.echo(str(e))
 
 
-@credentials.command(help="Allows for east fetch of stored credentials on any platform.", name="get")
+@credentials.command(help="Allows for easy fetch of stored credentials on any platform.", name="get")
 @click.option('-i', '--identifier', prompt='Enter identifier',
               help="Name of service you want to get a value for.  Username will always be 'user_sync'.")
 def get_credential(identifier):

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -34,7 +34,6 @@ import user_sync.port
 import user_sync.rules
 from user_sync import flags
 from user_sync.error import AssertionException
-import user_sync.credentials
 
 
 class ConfigLoader(object):

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -271,33 +271,24 @@ class UmapiCredentialConfig(CredentialConfig):
 
     def revert(self):
         creds = {}
+        creds['enterprise'] = {
+            'api_key': self.revert_key(['enterprise', 'api_key']),
+            'client_secret': self.revert_key(['enterprise', 'client_secret'])
+        }
         if self.get_nested_key(['enterprise', 'priv_key_pass']) is not None:
-            creds['enterprise'] = {
-                'api_key': self.revert_key(['enterprise', 'api_key']),
-                'client_secret': self.revert_key(['enterprise', 'client_secret']),
-                'priv_key_pass': self.revert_key(['enterprise', 'priv_key_pass'])
-            }
-        else:
-            creds['enterprise'] = {
-                'api_key': self.revert_key(['enterprise', 'api_key']),
-                'client_secret': self.revert_key(['enterprise', 'client_secret'])
-            }
+            creds['enterprise']['priv_key_pass'] = self.revert_key(['enterprise', 'priv_key_pass'])
         self.save()
         return creds
 
     def retrieve(self):
         creds = {}
+        creds['enterprise'] = {
+            'api_key': self.retrieve_key(['enterprise', 'api_key']),
+            'client_secret': self.retrieve_key(['enterprise', 'client_secret'])
+        }
         if self.get_nested_key(['enterprise', 'priv_key_pass']) is not None:
-            creds['enterprise'] = {
-                'api_key': self.retrieve_key(['enterprise', 'api_key']),
-                'client_secret': self.retrieve_key(['enterprise', 'client_secret']),
-                'priv_key_pass': self.retrieve_key(['enterprise', 'priv_key_pass'])
-            }
-        else:
-            creds['enterprise'] = {
-                'api_key': self.retrieve_key(['enterprise', 'api_key']),
-                'client_secret': self.retrieve_key(['enterprise', 'client_secret'])
-            }
+            creds['enterprise']['priv_key_pass'] = self.retrieve_key(['enterprise', 'priv_key_pass'])
+        self.save()
         return creds
 
 
@@ -336,31 +327,22 @@ class ConsoleCredentialConfig(CredentialConfig):
 
     def revert(self):
         creds = {}
+        creds['integration'] = {
+            'api_key': self.revert_key(['integration', 'api_key']),
+            'client_secret': self.revert_key(['integration', 'client_secret'])
+        }
         if self.get_nested_key(['integration', 'priv_key_pass']) is not None:
-            creds['integration'] = {
-                'api_key': self.revert_key(['integration', 'api_key']),
-                'client_secret': self.revert_key(['integration', 'client_secret']),
-                'priv_key_pass': self.revert_key(['integration', 'priv_key_pass'])
-            }
-        else:
-            creds['integration'] = {
-                'api_key': self.revert_key(['integration', 'api_key']),
-                'client_secret': self.revert_key(['integration', 'client_secret'])
-            }
+            creds['integration']['priv_key_pass'] = self.revert_key(['integration', 'priv_key_pass'])
         self.save()
         return creds
 
     def retrieve(self):
         creds = {}
+        creds['integration'] = {
+            'api_key': self.retrieve_key(['integration', 'api_key']),
+            'client_secret': self.retrieve_key(['integration', 'client_secret'])
+        }
         if self.get_nested_key(['integration', 'priv_key_pass']) is not None:
-            creds['integration'] = {
-                'api_key': self.retrieve_key(['integration', 'api_key']),
-                'client_secret': self.retrieve_key(['integration', 'client_secret']),
-                'priv_key_pass': self.retrieve_key(['integration', 'priv_key_pass'])
-            }
-        else:
-            creds['integration'] = {
-                'api_key': self.retrieve_key(['integration', 'api_key']),
-                'client_secret': self.retrieve_key(['integration', 'client_secret'])
-            }
+            creds['integration']['priv_key_pass'] = self.retrieve_key(['integration', 'priv_key_pass'])
+        self.save()
         return creds

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -213,7 +213,7 @@ class CredentialConfig:
     def revert_key(self, key_list):
         plaintext_cred = self.retrieve_key(key_list)
         if plaintext_cred is None:
-            raise AssertionException('No secure key found for given identifier.')
+            raise AssertionException("No secure key found for: '{0}'".format(key_list))
         self.set_nested_key(key_list, plaintext_cred)
         return plaintext_cred
 
@@ -265,23 +265,39 @@ class UmapiCredentialConfig(CredentialConfig):
     def store(self):
         self.store_key(['enterprise', 'api_key'])
         self.store_key(['enterprise', 'client_secret'])
+        if self.get_nested_key(['enterprise', 'priv_key_pass']) is not None:
+            self.store_key(['enterprise', 'priv_key_pass'])
         self.save()
 
     def revert(self):
         creds = {}
-        creds['enterprise'] = {
-            'api_key': self.revert_key(['enterprise', 'api_key']),
-            'client_secret': self.revert_key(['enterprise', 'client_secret'])
-        }
+        if self.get_nested_key(['enterprise', 'priv_key_pass']) is not None:
+            creds['enterprise'] = {
+                'api_key': self.revert_key(['enterprise', 'api_key']),
+                'client_secret': self.revert_key(['enterprise', 'client_secret']),
+                'priv_key_pass': self.revert_key(['enterprise', 'priv_key_pass'])
+            }
+        else:
+            creds['enterprise'] = {
+                'api_key': self.revert_key(['enterprise', 'api_key']),
+                'client_secret': self.revert_key(['enterprise', 'client_secret'])
+            }
         self.save()
         return creds
 
     def retrieve(self):
         creds = {}
-        creds['enterprise'] = {
-            'api_key': self.retrieve_key(['enterprise', 'api_key']),
-            'client_secret': self.retrieve_key(['enterprise', 'client_secret'])
-        }
+        if self.get_nested_key(['enterprise', 'priv_key_pass']) is not None:
+            creds['enterprise'] = {
+                'api_key': self.retrieve_key(['enterprise', 'api_key']),
+                'client_secret': self.retrieve_key(['enterprise', 'client_secret']),
+                'priv_key_pass': self.retrieve_key(['enterprise', 'priv_key_pass'])
+            }
+        else:
+            creds['enterprise'] = {
+                'api_key': self.retrieve_key(['enterprise', 'api_key']),
+                'client_secret': self.retrieve_key(['enterprise', 'client_secret'])
+            }
         return creds
 
 
@@ -314,21 +330,37 @@ class ConsoleCredentialConfig(CredentialConfig):
     def store(self):
         self.store_key(['integration', 'api_key'])
         self.store_key(['integration', 'client_secret'])
+        if self.get_nested_key(['integration', 'priv_key_pass']) is not None:
+            self.store_key(['integration', 'priv_key_pass'])
         self.save()
 
     def revert(self):
         creds = {}
-        creds['integration'] = {
-            'api_key': self.revert_key(['integration', 'api_key']),
-            'client_secret': self.revert_key(['integration', 'client_secret'])
-        }
+        if self.get_nested_key(['integration', 'priv_key_pass']) is not None:
+            creds['integration'] = {
+                'api_key': self.revert_key(['integration', 'api_key']),
+                'client_secret': self.revert_key(['integration', 'client_secret']),
+                'priv_key_pass': self.revert_key(['integration', 'priv_key_pass'])
+            }
+        else:
+            creds['integration'] = {
+                'api_key': self.revert_key(['integration', 'api_key']),
+                'client_secret': self.revert_key(['integration', 'client_secret'])
+            }
         self.save()
         return creds
 
     def retrieve(self):
         creds = {}
-        creds['integration'] = {
-            'api_key': self.retrieve_key(['integration', 'api_key']),
-            'client_secret': self.retrieve_key(['integration', 'client_secret'])
-        }
+        if self.get_nested_key(['integration', 'priv_key_pass']) is not None:
+            creds['integration'] = {
+                'api_key': self.retrieve_key(['integration', 'api_key']),
+                'client_secret': self.retrieve_key(['integration', 'client_secret']),
+                'priv_key_pass': self.retrieve_key(['integration', 'priv_key_pass'])
+            }
+        else:
+            creds['integration'] = {
+                'api_key': self.retrieve_key(['integration', 'api_key']),
+                'client_secret': self.retrieve_key(['integration', 'client_secret'])
+            }
         return creds

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -217,6 +217,7 @@ class CredentialConfig:
         self.set_nested_key(key_list, plaintext_cred)
         return plaintext_cred
 
+    @classmethod
     def parse_secure_key(self, value):
         """
         Returns the identifier for the secure key if present, or else None

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -263,19 +263,15 @@ class UmapiCredentialConfig(CredentialConfig):
     """
 
     def store(self):
-        self.store_key(['enterprise', 'org_id'])
         self.store_key(['enterprise', 'api_key'])
         self.store_key(['enterprise', 'client_secret'])
-        self.store_key(['enterprise', 'tech_acct'])
         self.save()
 
     def revert(self):
         creds = {}
         creds['enterprise'] = {
-            'org_id': self.revert_key(['enterprise', 'org_id']),
             'api_key': self.revert_key(['enterprise', 'api_key']),
-            'client_secret': self.revert_key(['enterprise', 'client_secret']),
-            'tech_acct': self.revert_key(['enterprise', 'tech_acct'])
+            'client_secret': self.revert_key(['enterprise', 'client_secret'])
         }
         self.save()
         return creds
@@ -283,10 +279,8 @@ class UmapiCredentialConfig(CredentialConfig):
     def retrieve(self):
         creds = {}
         creds['enterprise'] = {
-            'org_id': self.retrieve_key(['enterprise', 'org_id']),
             'api_key': self.retrieve_key(['enterprise', 'api_key']),
-            'client_secret': self.retrieve_key(['enterprise', 'client_secret']),
-            'tech_acct': self.retrieve_key(['enterprise', 'tech_acct'])
+            'client_secret': self.retrieve_key(['enterprise', 'client_secret'])
         }
         return creds
 
@@ -318,19 +312,15 @@ class ConsoleCredentialConfig(CredentialConfig):
     """
 
     def store(self):
-        self.store_key(['integration', 'org_id'])
         self.store_key(['integration', 'api_key'])
         self.store_key(['integration', 'client_secret'])
-        self.store_key(['integration', 'tech_acct'])
         self.save()
 
     def revert(self):
         creds = {}
         creds['integration'] = {
-            'org_id': self.revert_key(['integration', 'org_id']),
             'api_key': self.revert_key(['integration', 'api_key']),
-            'client_secret': self.revert_key(['integration', 'client_secret']),
-            'tech_acct': self.revert_key(['integration', 'tech_acct'])
+            'client_secret': self.revert_key(['integration', 'client_secret'])
         }
         self.save()
         return creds
@@ -338,9 +328,7 @@ class ConsoleCredentialConfig(CredentialConfig):
     def retrieve(self):
         creds = {}
         creds['integration'] = {
-            'org_id': self.retrieve_key(['integration', 'org_id']),
             'api_key': self.retrieve_key(['integration', 'api_key']),
-            'client_secret': self.retrieve_key(['integration', 'client_secret']),
-            'tech_acct': self.retrieve_key(['integration', 'tech_acct'])
+            'client_secret': self.retrieve_key(['integration', 'client_secret'])
         }
         return creds

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -225,7 +225,7 @@ class CredentialConfig:
         containing exactly one key named 'secure' whose value is the identifier in keyring.
         """
         if value is None:
-            raise AssertionException("Key is missing or emtpy:" + str(value))
+            return None
         if isinstance(value, dict):
             if len(value) == 1 and 'secure' in value:
                 return value['secure']


### PR DESCRIPTION
Modified the get_credential method from config.py to return the correct credential given any of the three possible formats - plaintext, secure_x_key, and the secure dict (new format). 