### PR TITLE
Ensure native line encoding test for examples works everywhere

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2016-2017 Adobe Inc.  All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from click.testing import CliRunner
+from user_sync.app import example_config
+import sys
+import shutil
+from pathlib import Path
+from user_sync import resource
+
+
+def test_example_config_line_endings(tmpdir, monkeypatch, tmp_config_files):
+    # Set up temp directories
+    res_path = tmpdir / 'resource'
+    res_path.mkdir()
+    example_path = tmpdir / 'examples'
+    example_path.mkdir()
+
+    # Copy temp example config to temp resource dir
+    (root_tmp_file, ldap_tmp_file, umapi_tmp_file) = tmp_config_files
+
+    shutil.copyfile(ldap_tmp_file, res_path / Path(ldap_tmp_file).parts[-1])
+    shutil.copyfile(root_tmp_file, res_path / Path(root_tmp_file).parts[-1])
+    shutil.copyfile(umapi_tmp_file, res_path / Path(umapi_tmp_file).parts[-1])
+
+    # patch pkg_resources
+    def resource_patch(res):
+        if 'ldap' in res:
+            return str(res_path / Path(ldap_tmp_file).parts[-1])
+        if 'user-sync' in res:
+            return str(res_path / Path(root_tmp_file).parts[-1])
+        if 'umapi' in res:
+            return str(res_path / Path(umapi_tmp_file).parts[-1])
+        return ''
+
+    with monkeypatch.context() as m:
+        m.setattr(resource, "get_resource", resource_patch)
+
+        runner = CliRunner()
+        example_ldap_file = example_path / Path(ldap_tmp_file).parts[-1]
+        example_ust_file = example_path / Path(root_tmp_file).parts[-1]
+        example_umapi_file = example_path / Path(umapi_tmp_file).parts[-1]
+        runner.invoke(example_config, ['--ldap={}'.format(example_ldap_file), '--root={}'.format(example_ust_file),
+                                       '--umapi={}'.format(example_umapi_file)])
+
+        with open(example_ldap_file, 'rb') as f:
+            content = f.read()
+        if sys.platform == 'win32':
+            assert b'\r\n' in content
+        else:
+            assert b'\n' in content
+            assert b'\r' not in content

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -19,14 +19,11 @@
 # SOFTWARE.
 
 
-from click.testing import CliRunner
-
 import os
 import sys
 import pytest
 import pkg_resources
 from user_sync import resource
-from user_sync.app import example_config
 
 
 def test_resource_file_bundle(resource_file, tmpdir, monkeypatch):
@@ -146,16 +143,3 @@ def test_resource_dir_invalid(tmpdir, monkeypatch):
 
         with pytest.raises(AssertionError):
             resource.get_resource_dir('test')
-
-
-def test_example_config_line_endings(tmp_config_files):
-    (_,ldap_config_file,_)=tmp_config_files
-    runner = CliRunner()
-    runner.invoke(example_config)
-    with open('connector-ldap.yml', 'rb') as f:
-        content = f.read()
-    if sys.platform == 'win32':
-        assert b'\r\n' in content
-    else:
-        assert b'\n' in content
-        assert b'\r' not in content


### PR DESCRIPTION
I've updated the test that checks native line encoding in the example configs.

* Test should not be in `test_resource` since we're not testing the resource module
* I've create a new test module for CLI tests
* The test now has a lot of setup - we need to copy the config file fixtures to a dummy "resources" directory and patch `resource.get_resource()` to return paths relative to that dummy directory
* Specify temp file paths to `example-config` invocation