### PR TITLE
Removal of has_credential, refactor of make_auth_dict

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -227,4 +227,5 @@ def test_get_credential_old_format(tmp_config_files):
     credman.set('ldap_secure_identifier', 'test_password')
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
+    # this would fail if the client followed the old directions and set the username to the org_id!!
     assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -224,8 +224,8 @@ def test_get_credential_old_format(tmp_config_files):
     ldap_config['secure_password_key'] = 'ldap_secure_identifier'
     with pytest.raises(AssertionException):
         ldap_dict_config.get_credential('password', 'user_sync')
-    credman.set('ldap_secure_identifier', 'test_password')
+    username = ldap_config['username']
+    credman.set('ldap_secure_identifier', 'test_password', username)
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
-    # this would fail if the client followed the old directions and set the username to the org_id!!
     assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -228,4 +228,4 @@ def test_get_credential_old_format(tmp_config_files):
     credman.set('ldap_secure_identifier', 'test_password', username)
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
-    assert ldap_dict_config.get_credential('password', 'user_sync') == 'test_password'
+    assert ldap_dict_config.get_credential('password', username) == 'test_password'

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -1,0 +1,26 @@
+import pytest
+
+from user_sync.config import ConfigFileLoader, DictConfig
+from user_sync.connector.umapi_util import has_credential
+from user_sync.error import AssertionException
+
+
+def test_has_credential(umapi_config_file, private_key):
+    umapi_config = ConfigFileLoader.load_from_yaml(umapi_config_file, {})
+    umapi_dict_config = DictConfig('testscope', umapi_config)
+    # with no changes the default umapi config, there will be no key for priv_key_data,
+    # so has_credential should return none (it is only called for priv_key_data)
+    assert has_credential('priv_key_data', umapi_dict_config) is None
+    # if there is a value for priv_key_data then has_credential simply returns the name passed in
+    umapi_config['priv_key_data'] = 'keydata'
+    assert has_credential('priv_key_data', umapi_dict_config) == 'priv_key_data'
+    # if there is also a setting for 'secure_priv_key_data_key' it should throw an AssertionException
+    umapi_config['secure_priv_key_data_key'] = 'secure key data'
+    with pytest.raises(AssertionException):
+        data = has_credential('priv_key_data', umapi_dict_config)
+    umapi_config['priv_key_data'] = None
+    # if there is only the secure key format then has_credential returns the secure key
+    assert has_credential('priv_key_data', umapi_dict_config) == 'secure_priv_key_data_key'
+
+
+

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -1,26 +1,39 @@
 import pytest
 
 from user_sync.config import ConfigFileLoader, DictConfig
-from user_sync.connector.umapi_util import has_credential
+from user_sync.connector.umapi_util import make_auth_dict
 from user_sync.error import AssertionException
+import user_sync.connector.helper
+from user_sync.credentials import CredentialConfig
 
 
-def test_has_credential(umapi_config_file, private_key):
+def test_make_auth_dict(umapi_config_file, private_key):
     umapi_config = ConfigFileLoader.load_from_yaml(umapi_config_file, {})
-    umapi_dict_config = DictConfig('testscope', umapi_config)
-    # with no changes the default umapi config, there will be no key for priv_key_data,
-    # so has_credential should return none (it is only called for priv_key_data)
-    assert has_credential('priv_key_data', umapi_dict_config) is None
-    # if there is a value for priv_key_data then has_credential simply returns the name passed in
-    umapi_config['priv_key_data'] = 'keydata'
-    assert has_credential('priv_key_data', umapi_dict_config) == 'priv_key_data'
-    # if there is also a setting for 'secure_priv_key_data_key' it should throw an AssertionException
-    umapi_config['secure_priv_key_data_key'] = 'secure key data'
-    with pytest.raises(AssertionException):
-        data = has_credential('priv_key_data', umapi_dict_config)
-    umapi_config['priv_key_data'] = None
-    # if there is only the secure key format then has_credential returns the secure key
-    assert has_credential('priv_key_data', umapi_dict_config) == 'secure_priv_key_data_key'
+    umapi_config['enterprise']['priv_key_path'] = private_key
+    # note that the private_key fixture is actually just the absolute path to test_private.key in the fixture dir
+    umapi_dict_config = DictConfig('enterprise', umapi_config['enterprise'])
+    org_id_from_file = umapi_config['enterprise']['org_id']
+    tech_acct_from_file = umapi_config['enterprise']['tech_acct']
+    api_key_from_file = umapi_config['enterprise']['api_key']
+    client_secret_from_file = umapi_config['enterprise']['client_secret']
+    logger = user_sync.connector.helper.create_logger({})
+    name = 'umapi'
+    auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
+    assert auth_dict['org_id'] == org_id_from_file
+    assert auth_dict['tech_acct_id'] == tech_acct_from_file
+    assert auth_dict['api_key'] == api_key_from_file
+    assert auth_dict['client_secret'] == client_secret_from_file
+    with open(private_key) as f:
+        key_data_from_file = f.read()
+    assert auth_dict['private_key_data'] == key_data_from_file
+    # set priv_key_path to none and use priv_key_data instead
+    umapi_config['enterprise']['priv_key_path'] = None
+    umapi_config['enterprise']['priv_key_data'] = key_data_from_file
+    # make sure that auth dict will still return the key data correctly
+    auth_dict_key_data = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
+    assert auth_dict_key_data['private_key_data'] == key_data_from_file
+
+
 
 
 

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -40,10 +40,8 @@ def test_make_auth_dict(umapi_config_file, private_key):
     with pytest.raises(AssertionException):
         invalid_auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     # and if there is only the secure format it should work as long as the credential has been set
-    # can't get the username right. need user_sync not org_id
     credman = CredentialManager()
-    credman.set('make_auth_identifier', 'keydata')
-    # have to go manually the the username as org_id for this to work
+    credman.set('make_auth_identifier', 'keydata', org_id_from_file)
     umapi_config['enterprise']['priv_key_data'] = None
     auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     assert auth_dict['private_key_data'] == 'keydata'

--- a/user_sync/config.py
+++ b/user_sync/config.py
@@ -814,25 +814,6 @@ class DictConfig(ObjectConfig):
     keyring_prefix = 'secure_'
     keyring_suffix = '_key'
 
-    def has_credential(self, name):
-        """
-        Check if there is a credential setting with the given name
-        :param name: plaintext setting name for the credential
-        :return: setting that was specified, or None if none was
-        """
-        scope = self.get_full_scope()
-        keyring_name = self.keyring_prefix + name + self.keyring_suffix
-        plaintext = self.get_string(name, True)
-        secure = self.get_string(keyring_name, True)
-        if plaintext and secure:
-            raise AssertionException('%s: cannot contain setting for both "%s" and "%s"' % (scope, name, keyring_name))
-        if plaintext is not None:
-            return name
-        elif secure is not None:
-            return keyring_name
-        else:
-            return None
-
     def get_credential(self, name, username, none_allowed=False):
         """
         Get the credential with the given name.  Raises an AssertionException if there

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -30,7 +30,7 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     else:
         try:
             # this covers the case of having both the plaintext and secure format for priv_key_data
-            key_data = config.get_credential('priv_key_data', org_id, True)
+            key_data = config.get_credential('priv_key_data', org_id)
         except AssertionException as e:
             raise e
     # decrypt the private key, if needed

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -11,11 +11,21 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     }
     # get the private key
     key_path = config.get_string('priv_key_path', True)
-    if key_path:
-        data_setting = has_credential('priv_key_data', config)
-        if data_setting:
-            raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
-                                     (config.get_full_scope(), data_setting))
+    data_setting = config.get_string('priv_key_data', True)
+    secure_data_setting = config.get_string(config.keyring_prefix + 'priv_key_data' + config.keyring_suffix, True)
+    if data_setting or secure_data_setting:
+        try:
+            # this covers the case of having both the plaintext and secure format for priv_key_data
+            key_data = config.get_credential('priv_key_data', org_id, True)
+        except AssertionException as e:
+            raise e
+    elif key_path and data_setting:
+        raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
+                                 (config.get_full_scope(), data_setting))
+    elif key_path and secure_data_setting:
+        raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
+                                 (config.get_full_scope(), secure_data_setting))
+    elif key_path is not None:
         logger.debug('%s: reading private key data from file %s', name, key_path)
         try:
             with open(key_path, 'r') as f:
@@ -24,7 +34,7 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
             raise AssertionException('%s: cannot read file "%s": %s' %
                                      (config.get_full_scope(), key_path, e))
     else:
-        key_data = config.get_credential('priv_key_data', org_id)
+        raise AssertionException('No value found for priv_key_path or priv_key_data')
     # decrypt the private key, if needed
     passphrase = config.get_credential('priv_key_pass', org_id, True)
     if passphrase:

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -13,13 +13,7 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     key_path = config.get_string('priv_key_path', True)
     data_setting = config.get_string('priv_key_data', True)
     secure_data_setting = config.get_string(config.keyring_prefix + 'priv_key_data' + config.keyring_suffix, True)
-    if data_setting or secure_data_setting:
-        try:
-            # this covers the case of having both the plaintext and secure format for priv_key_data
-            key_data = config.get_credential('priv_key_data', org_id, True)
-        except AssertionException as e:
-            raise e
-    elif key_path and data_setting:
+    if key_path and data_setting:
         raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
                                  (config.get_full_scope(), data_setting))
     elif key_path and secure_data_setting:
@@ -34,7 +28,11 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
             raise AssertionException('%s: cannot read file "%s": %s' %
                                      (config.get_full_scope(), key_path, e))
     else:
-        raise AssertionException('No value found for priv_key_path or priv_key_data')
+        try:
+            # this covers the case of having both the plaintext and secure format for priv_key_data
+            key_data = config.get_credential('priv_key_data', org_id, True)
+        except AssertionException as e:
+            raise e
     # decrypt the private key, if needed
     passphrase = config.get_credential('priv_key_pass', org_id, True)
     if passphrase:

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -12,7 +12,7 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     # get the private key
     key_path = config.get_string('priv_key_path', True)
     if key_path:
-        data_setting = has_credential('priv_key_data')
+        data_setting = has_credential('priv_key_data', config)
         if data_setting:
             raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
                                      (config.get_full_scope(), data_setting))
@@ -37,17 +37,17 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     return auth_dict
 
 
-def has_credential(name):
+def has_credential(name, config):
     """
     Check if there is a credential setting with the given name
     :param name: plaintext setting name for the credential
+    :param config: DictConfig object passed in from umapi_util.make_auth_dict
     :return: setting that was specified, or None if none was
     """
-    from user_sync.config import ObjectConfig, DictConfig
-    scope = ObjectConfig.get_full_scope()
-    keyring_name = DictConfig.keyring_prefix + name + DictConfig.keyring_suffix
-    plaintext = DictConfig.get_string(name, True)
-    secure = DictConfig.get_string(keyring_name, True)
+    scope = config.get_full_scope()
+    keyring_name = config.keyring_prefix + name + config.keyring_suffix
+    plaintext = config.get_string(name, True)
+    secure = config.get_string(keyring_name, True)
     if plaintext and secure:
         raise AssertionException('%s: cannot contain setting for both "%s" and "%s"' % (scope, name, keyring_name))
     if plaintext is not None:

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -12,7 +12,7 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     # get the private key
     key_path = config.get_string('priv_key_path', True)
     if key_path:
-        data_setting = config.has_credential('priv_key_data')
+        data_setting = has_credential('priv_key_data')
         if data_setting:
             raise AssertionException('%s: cannot specify both "priv_key_path" and "%s"' %
                                      (config.get_full_scope(), data_setting))
@@ -35,3 +35,24 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
                                      (config.get_full_scope(), e))
     auth_dict['private_key_data'] = key_data
     return auth_dict
+
+
+def has_credential(name):
+    """
+    Check if there is a credential setting with the given name
+    :param name: plaintext setting name for the credential
+    :return: setting that was specified, or None if none was
+    """
+    from user_sync.config import ObjectConfig, DictConfig
+    scope = ObjectConfig.get_full_scope()
+    keyring_name = DictConfig.keyring_prefix + name + DictConfig.keyring_suffix
+    plaintext = DictConfig.get_string(name, True)
+    secure = DictConfig.get_string(keyring_name, True)
+    if plaintext and secure:
+        raise AssertionException('%s: cannot contain setting for both "%s" and "%s"' % (scope, name, keyring_name))
+    if plaintext is not None:
+        return name
+    elif secure is not None:
+        return keyring_name
+    else:
+        return None

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -43,24 +43,3 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
                                      (config.get_full_scope(), e))
     auth_dict['private_key_data'] = key_data
     return auth_dict
-
-
-def has_credential(name, config):
-    """
-    Check if there is a credential setting with the given name
-    :param name: plaintext setting name for the credential
-    :param config: DictConfig object passed in from umapi_util.make_auth_dict
-    :return: setting that was specified, or None if none was
-    """
-    scope = config.get_full_scope()
-    keyring_name = config.keyring_prefix + name + config.keyring_suffix
-    plaintext = config.get_string(name, True)
-    secure = config.get_string(keyring_name, True)
-    if plaintext and secure:
-        raise AssertionException('%s: cannot contain setting for both "%s" and "%s"' % (scope, name, keyring_name))
-    if plaintext is not None:
-        return name
-    elif secure is not None:
-        return keyring_name
-    else:
-        return None

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -44,10 +44,10 @@ class CredentialManager:
             raise AssertionException("Error retrieving value for identifier '{0}': {1}".format(identifier, str(e)))
 
     @classmethod
-    def set(cls, identifier, value):
+    def set(cls, identifier, value, username=None):
         try:
             cls.logger.debug("Using keyring '{0}' to set '{1}'".format(cls.keyring_name, identifier))
-            keyring.set_password(identifier, cls.username, value)
+            keyring.set_password(identifier, username or cls.username, value)
         except KeyringError as e:
             raise AssertionException("Error in setting credentials '{0}' : {1}".format(identifier, str(e)))
         except Exception as e:


### PR DESCRIPTION
The has_credential method is no more. The one call that was being made to it has been accounted for in make_auth_dict. I made one slight change in the CredentialManager class so that the set method can be used with a specified username (if that parameter is left out it still uses the default username for the class). This really only serves a purpose for testing (set is not callable from app.py with a username parameter) since it still would have worked for users to manually set the value in keyring with their org_id as the username.