### PR TITLE
Dale priv key storage

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -27,8 +27,8 @@ def test_nested_set(ldap_config_file):
 def test_retrieve_ldap_creds_valid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = ['password']
-    plaintext_cred = c.get_nested_key(key_list)
+    key_list = Credential(['password'])
+    plaintext_cred = c.get_nested_key(key_list.credential)
     c.store_key(key_list)
     retrieved_plaintext_cred = c.retrieve_key(key_list)
     assert retrieved_plaintext_cred == plaintext_cred
@@ -37,7 +37,7 @@ def test_retrieve_ldap_creds_valid(tmp_config_files):
 def test_retrieve_ldap_creds_invalid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = ['password']
+    key_list = Credential(['password'])
     # if store_key has not been called previously, retrieve_key returns None
     assert c.retrieve_key(key_list) is None
 
@@ -45,8 +45,8 @@ def test_retrieve_ldap_creds_invalid(tmp_config_files):
 def test_revert_valid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = ['password']
-    plaintext_cred = c.get_nested_key(key_list)
+    key_list = Credential(['password'])
+    plaintext_cred = c.get_nested_key(key_list.credential)
     c.store_key(key_list)
     reverted_plaintext_cred = c.revert_key(key_list)
     assert reverted_plaintext_cred == plaintext_cred
@@ -55,7 +55,7 @@ def test_revert_valid(tmp_config_files):
 def test_revert_invalid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = ['password']
+    key_list = Credential(['password'])
     # assume store_key has not been called
     assert c.revert_key(key_list) is None
 
@@ -189,7 +189,8 @@ def test_get_not_valid():
 def test_config_store(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    assert not ldap.parse_secure_key(ldap.get_nested_key(['password']))
+    key_list = Credential(['password'])
+    assert not ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
     ldap.store()
     with open(ldap_config_file) as f:
         data = yaml.load(f)
@@ -199,14 +200,16 @@ def test_config_store(tmp_config_files):
 def test_config_store_key(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    assert not ldap.parse_secure_key(ldap.get_nested_key(['password']))
-    ldap.store_key(['password'])
-    assert ldap.parse_secure_key(ldap.get_nested_key(['password']))
+    key_list = Credential(['password'])
+    assert not ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
+    ldap.store_key(key_list)
+    assert ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
 
 
 def test_config_store_key_none(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    ldap.set_nested_key(['password'], [])
+    key_list = Credential(['password'])
+    ldap.set_nested_key(key_list.credential, [])
     with pytest.raises(AssertionException):
-        ldap.store_key(['password'])
+        ldap.store_key(key_list)

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -440,6 +440,7 @@ def log_credentials(credentials, show_values=False):
     for file, cred in credentials.items():
         click.echo('\n' + file.split(os.sep)[-1] + ":")
         for k, v in cred.items():
+            # conditional for priv key data
             click.echo("  " + k + (": " + v if show_values else ""))
 
 

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -440,8 +440,10 @@ def log_credentials(credentials, show_values=False):
     for file, cred in credentials.items():
         click.echo('\n' + file.split(os.sep)[-1] + ":")
         for k, v in cred.items():
-            # conditional for priv key data
-            click.echo("  " + k + (": " + v if show_values else ""))
+            if k == 'enterprise:priv_key_data':
+                click.echo("  " + k + (": " + v[40:80] + ' (partial data)' if show_values else ""))
+            else:
+                click.echo("  " + k + (": " + v if show_values else ""))
 
 
 @credentials.command(

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -52,6 +52,8 @@ class CredentialManager:
             raise AssertionException("Error in setting credentials '{0}' : {1}".format(identifier, str(e)))
         except Exception as e:
             if "stub received bad data" in str(e):
+                cls.logger.warning("{0} does not support private key storage. "
+                                   "Encrypt private key instead?".format(cls.keyring_name))
                 raise AssertionException("Value for {0} too long for backend to store: {1}".format(identifier, str(e)))
             raise e
 
@@ -251,7 +253,8 @@ class UmapiCredentialConfig(CredentialConfig):
     secured_keys = [
         ['enterprise', 'api_key'],
         ['enterprise', 'client_secret'],
-        ['enterprise', 'priv_key_pass']
+        ['enterprise', 'priv_key_pass'],
+        ['enterprise', 'priv_key_data']
     ]
 
 
@@ -259,5 +262,6 @@ class ConsoleCredentialConfig(CredentialConfig):
     secured_keys = [
         ['integration', 'api_key'],
         ['integration', 'client_secret'],
-        ['integration', 'priv_key_pass']
+        ['integration', 'priv_key_pass'],
+        ['integration', 'priv_key_data']
     ]

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -243,33 +243,33 @@ class CredentialConfig:
 
 
 class Credential:
-    def __init__(self, credential, is_block):
+    def __init__(self, credential, is_block=False):
         self.credential = credential
         self.is_block = is_block
 
 
 class LdapCredentialConfig(CredentialConfig):
-    secured_keys = [Credential(['password'], is_block=False)]
+    secured_keys = [Credential(['password'])]
 
 
 class OktaCredentialConfig(CredentialConfig):
-    secured_keys = [Credential(['api_token'], is_block=False)]
+    secured_keys = [Credential(['api_token'])]
 
 
 class UmapiCredentialConfig(CredentialConfig):
     secured_keys = [
-        Credential(['enterprise', 'api_key'], is_block=False),
-        Credential(['enterprise', 'client_secret'], is_block=False),
-        Credential(['enterprise', 'priv_key_pass'], is_block=False),
+        Credential(['enterprise', 'api_key']),
+        Credential(['enterprise', 'client_secret']),
+        Credential(['enterprise', 'priv_key_pass']),
         Credential(['enterprise', 'priv_key_data'], is_block=True)
     ]
 
 
 class ConsoleCredentialConfig(CredentialConfig):
     secured_keys = [
-        Credential(['integration', 'api_key'], is_block=False),
-        Credential(['integration', 'client_secret'], is_block=False),
-        Credential(['integration', 'priv_key_pass'], is_block=False),
+        Credential(['integration', 'api_key']),
+        Credential(['integration', 'client_secret']),
+        Credential(['integration', 'priv_key_pass']),
         Credential(['integration', 'priv_key_data'], is_block=True)
     ]
 

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -5,6 +5,7 @@ import keyrings.cryptfile.cryptfile
 import six
 from keyring.errors import KeyringError
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import PreservedScalarString as pss
 
 from user_sync.config import ConfigFileLoader, ConfigLoader
 from user_sync.error import AssertionException
@@ -21,8 +22,6 @@ yaml = YAML()
 yaml.indent(mapping=4, sequence=4, offset=2)
 
 
-from ruamel.yaml.scalarstring import PreservedScalarString as pss
-# full_config['umapi']['enterprise']['priv_key_data'] = pss(x)
 
 class CredentialManager:
     username = 'user_sync'

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -52,7 +52,9 @@ class CredentialManager:
             raise AssertionException("Error in setting credentials '{0}' : {1}".format(identifier, str(e)))
         except Exception as e:
             if "stub received bad data" in str(e):
-                raise AssertionException("Bad value for {0} too long for backend to store: {1}".format(identifier, str(e)))
+                raise AssertionException("Bad value for {0}: {1} \nPrivate key data"
+                                         " storage may not be supported"
+                                         " due to character limits. Encrypt private key data instead?".format(identifier, str(e)))
             raise e
 
     def modify_credentials(self, action):


### PR DESCRIPTION
For each CredentialConfig subclass, the secured_key list is now a list of Credential objects instead of a list of lists. The Credential class has two attributes: a credential (a list of strings) and is_block (a boolean that is false unless specified otherwise as in the case of priv_key_data. The store, retrieve, and revert methods in CredentialConfig had to be slightly modified to act on the credential attribute of the key list instead of the key_list itself. In retrieve, a condition was added to check the is_block attribute and if so format the credential as a preserved scalar string.

I made minor changes to the error message that prints when Windows attempts to store the private key. I also added logic in app.py to check if the credential being printed to the console is a private key and if so slice the string and only print that section with the disclaimer that this is partial data.