### PR TITLE
private key encryption prompt

### DIFF
--- a/.build/.travis/build-py36-centos.sh
+++ b/.build/.travis/build-py36-centos.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-virtualenv venv -p /usr/bin/python3.6
+python3 -m venv venv
 source venv/bin/activate
 python -m pip install --upgrade pip
 pip install external/okta-0.0.3.1-py2.py3-none-any.whl

--- a/.build/.travis/install-centos.sh
+++ b/.build/.travis/install-centos.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
+yum update -y
 yum groupinstall -y "Development Tools"
-yum install -y epel-release
-yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-yum install -y python36u-devel python36u-pip python36u-virtualenv
-yum install -y python-devel python-pip python-virtualenv
+yum install -y python3 python3-devel
 yum install -y pkgconfig openssl-devel dbus-glib-devel dbus-python libffi-devel

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,7 +225,7 @@ def test_get_credential_old_format(tmp_config_files):
     with pytest.raises(AssertionException):
         ldap_dict_config.get_credential('password', 'user_sync')
     username = ldap_config['username']
-    credman.set('ldap_secure_identifier', 'test_password', username)
+    credman.set('ldap_secure_identifier', 'test_password', False, username)
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
     assert ldap_dict_config.get_credential('password', username) == 'test_password'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,7 +225,7 @@ def test_get_credential_old_format(tmp_config_files):
     with pytest.raises(AssertionException):
         ldap_dict_config.get_credential('password', 'user_sync')
     username = ldap_config['username']
-    credman.set('ldap_secure_identifier', 'test_password', False, username)
+    credman.set('ldap_secure_identifier', 'test_password', False, username=username)
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
     assert ldap_dict_config.get_credential('password', username) == 'test_password'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -225,7 +225,7 @@ def test_get_credential_old_format(tmp_config_files):
     with pytest.raises(AssertionException):
         ldap_dict_config.get_credential('password', 'user_sync')
     username = ldap_config['username']
-    credman.set('ldap_secure_identifier', 'test_password', False, username=username)
+    credman.set('ldap_secure_identifier', 'test_password', username=username)
     # set the plain key to None so get_credential will look for the secure_password_key format
     ldap_config['password'] = None
     assert ldap_dict_config.get_credential('password', username) == 'test_password'

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -27,37 +27,37 @@ def test_nested_set(ldap_config_file):
 def test_retrieve_ldap_creds_valid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
-    plaintext_cred = c.get_nested_key(key_list.credential)
-    c.store_key(key_list)
-    retrieved_plaintext_cred = c.retrieve_key(key_list)
+    key = Key(['password'])
+    plaintext_cred = c.get_nested_key(key.key_path)
+    c.store_key(key)
+    retrieved_plaintext_cred = c.retrieve_key(key)
     assert retrieved_plaintext_cred == plaintext_cred
 
 
 def test_retrieve_ldap_creds_invalid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
+    key = Key(['password'])
     # if store_key has not been called previously, retrieve_key returns None
-    assert c.retrieve_key(key_list) is None
+    assert c.retrieve_key(key) is None
 
 
 def test_revert_valid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
-    plaintext_cred = c.get_nested_key(key_list.credential)
-    c.store_key(key_list)
-    reverted_plaintext_cred = c.revert_key(key_list)
+    key = Key(['password'])
+    plaintext_cred = c.get_nested_key(key.key_path)
+    c.store_key(key)
+    reverted_plaintext_cred = c.revert_key(key)
     assert reverted_plaintext_cred == plaintext_cred
 
 
 def test_revert_invalid(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     c = CredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
+    key = Key(['password'])
     # assume store_key has not been called
-    assert c.revert_key(key_list) is None
+    assert c.revert_key(key) is None
 
 
 def test_retrieve_revert_ldap_valid(tmp_config_files):
@@ -84,7 +84,6 @@ def test_retrieve_revert_ldap_invalid(tmp_config_files):
     # if store has not been previously called before retrieve and revert we can expect the following
     retrieved_key_dict = ldap.retrieve()
     assert retrieved_key_dict == {}
-
     creds = ldap.revert()
     assert creds == {}
 
@@ -189,8 +188,8 @@ def test_get_not_valid():
 def test_config_store(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
-    assert not ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
+    key = Key(['password'])
+    assert not ldap.parse_secure_key(ldap.get_nested_key(key.key_path))
     ldap.store()
     with open(ldap_config_file) as f:
         data = yaml.load(f)
@@ -200,16 +199,16 @@ def test_config_store(tmp_config_files):
 def test_config_store_key(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
-    assert not ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
-    ldap.store_key(key_list)
-    assert ldap.parse_secure_key(ldap.get_nested_key(key_list.credential))
+    key = Key(['password'])
+    assert not ldap.parse_secure_key(ldap.get_nested_key(key.key_path))
+    ldap.store_key(key)
+    assert ldap.parse_secure_key(ldap.get_nested_key(key.key_path))
 
 
 def test_config_store_key_none(tmp_config_files):
     (_, ldap_config_file, _) = tmp_config_files
     ldap = LdapCredentialConfig(ldap_config_file)
-    key_list = Credential(['password'])
-    ldap.set_nested_key(key_list.credential, [])
+    key = Key(['password'])
+    ldap.set_nested_key(key.key_path, [])
     with pytest.raises(AssertionException):
-        ldap.store_key(key_list)
+        ldap.store_key(key)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -169,10 +169,8 @@ def test_set_long():
     value = "".join([str(uuid.uuid4()) for x in range(500)])
 
     if isinstance(keyring.get_keyring(), keyring.backends.Windows.WinVaultKeyring):
-        # a value that is too long for Windows sets off the encryption workflow for the private key
-        # the existing encryption format expects RSA format, so this random long string will trigger an exception there
-        with pytest.raises(AssertionException):
-            cm.set(identifier, value, True)
+        with pytest.raises(Exception):
+            cm.set(identifier, value)
     else:
         cm.set(identifier, value)
         assert cm.get(identifier) == value

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -210,5 +210,4 @@ def test_config_store_key_none(tmp_config_files):
     ldap = LdapCredentialConfig(ldap_config_file)
     key = Key(['password'])
     ldap.set_nested_key(key.key_path, [])
-    with pytest.raises(AssertionException):
-        ldap.store_key(key)
+    assert ldap.store_key(key) is None

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -170,8 +170,10 @@ def test_set_long():
     value = "".join([str(uuid.uuid4()) for x in range(500)])
 
     if isinstance(keyring.get_keyring(), keyring.backends.Windows.WinVaultKeyring):
+        # a value that is too long for Windows sets off the encryption workflow for the private key
+        # the existing encryption format expects RSA format, so this random long string will trigger an exception there
         with pytest.raises(AssertionException):
-            cm.set(identifier, value)
+            cm.set(identifier, value, True)
     else:
         cm.set(identifier, value)
         assert cm.get(identifier) == value

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -41,7 +41,7 @@ def test_make_auth_dict(umapi_config_file, private_key):
         invalid_auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     # and if there is only the secure format it should work as long as the credential has been set
     credman = CredentialManager()
-    credman.set('make_auth_identifier', 'keydata', org_id_from_file)
+    credman.set('make_auth_identifier', 'keydata', False, org_id_from_file)
     umapi_config['enterprise']['priv_key_data'] = None
     auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     assert auth_dict['private_key_data'] == 'keydata'

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -41,7 +41,7 @@ def test_make_auth_dict(umapi_config_file, private_key):
         invalid_auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     # and if there is only the secure format it should work as long as the credential has been set
     credman = CredentialManager()
-    credman.set('make_auth_identifier', 'keydata', False, username=org_id_from_file)
+    credman.set('make_auth_identifier', 'keydata', username=org_id_from_file)
     umapi_config['enterprise']['priv_key_data'] = None
     auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     assert auth_dict['private_key_data'] == 'keydata'

--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -41,7 +41,7 @@ def test_make_auth_dict(umapi_config_file, private_key):
         invalid_auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     # and if there is only the secure format it should work as long as the credential has been set
     credman = CredentialManager()
-    credman.set('make_auth_identifier', 'keydata', False, org_id_from_file)
+    credman.set('make_auth_identifier', 'keydata', False, username=org_id_from_file)
     umapi_config['enterprise']['priv_key_data'] = None
     auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     assert auth_dict['private_key_data'] == 'keydata'

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -460,12 +460,14 @@ def log_credentials(credentials, show_values=False):
               nargs=1,
               default="all",
               metavar='all|ldap|umapi|okta|console')
-def store(config_filename, type):
+@click.option('--auto-encrypt', '-a', help='Automatically encrypt private key data if storage fails.'
+                                           ' Passphrase will be randomly generated', is_flag=True)
+def store(config_filename, type, auto_encrypt):
     """
     Stores secure credentials in the configuration file. This is an automated process.
     """
     click.echo()
-    stored = CredentialManager(config_filename, type).store()
+    stored = CredentialManager(config_filename, type).store(auto_encrypt)
     if stored:
         click.echo("The following keys were stored:")
         log_credentials(stored)

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -37,7 +37,10 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
     passphrase = config.get_credential('priv_key_pass', org_id, True)
     if passphrase:
         try:
-            key_data = decrypt(passphrase, key_path)
+            # try to decrypt the private key data within the file first
+            key_data = decrypt(passphrase, key_data)
+            if key_data is None:
+                key_data = decrypt(passphrase, key_path)
         except (ValueError, IndexError, TypeError, AssertionException) as e:
             raise AssertionException('%s: Error decrypting private key, either the password is wrong or: %s' %
                                      (config.get_full_scope(), e))

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -141,6 +141,7 @@ class CredentialConfig:
                             raise AssertionException("Private key will remain in plaintext, unencrypted format.")
                     self.set_nested_key(k.key_path, pss(data))
                     self.store_key(Key(['enterprise', 'priv_key_pass']), value=passphrase)
+                    credentials[':'.join(['enterprise', 'priv_key_pass'])] = self.get_qualified_identifier(['enterprise', 'priv_key_pass'])
                 else:
                     raise e
         return credentials

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -55,7 +55,7 @@ class CredentialManager:
         except Exception as e:
             if "stub received bad data" in str(e):
                 # check that private key is in plaintext, unencrypted state?
-                if auto_encrypt[0]:
+                if auto_encrypt:
                     return cls.encrypt(value, *auto_encrypt)
                 else:
                     response = click.prompt("Bad value for '{0}': '{1}'. \nPrivate key storage may not be supported"
@@ -66,6 +66,8 @@ class CredentialManager:
                     else:
                         # not sure if necessary and if so what to do in this case
                         raise AssertionException("Private key will remain in plaintext, unencrypted format.")
+            else:
+                raise e
 
     @classmethod
     def encrypt(cls, data, *auto_encrypt):
@@ -143,14 +145,11 @@ class CredentialConfig:
             try:
                 # Try to do the action, but don't break on exception because rest of actions
                 # can still be completed
-<<<<<<< HEAD
                 if action == self.store_key:
-                    val = action(c, *auto_encrypt)
+                    val = action(k, *auto_encrypt)
                 else:
-                    val = action(c)
-=======
+                    val = action(k)
                 val = action(k)
->>>>>>> no-str-creds
                 if val is not None:
                     credentials[':'.join(k.key_path)] = val
             except AssertionException as e:
@@ -188,11 +187,7 @@ class CredentialConfig:
         """
         return self.filename + ":" + ":".join(identifier)
 
-<<<<<<< HEAD
-    def store_key(self, key_list, *auto_encrypt):
-=======
-    def store_key(self, key):
->>>>>>> no-str-creds
+    def store_key(self, key, *auto_encrypt):
         """
         Takes a list of keys representing the path to a value in the YAML file, and constructs an identifier.
         If the key is a string and NOT in secure format, calls credential manager to set the key
@@ -204,25 +199,19 @@ class CredentialConfig:
         if value is None:
             return
         if not self.parse_secure_key(value):
-<<<<<<< HEAD
-            k = self.get_qualified_identifier(key_list)
-            value = CredentialManager.set(k, value, *auto_encrypt)
-            if value is not None:
-                self.set_nested_key(key_list, pss(value))
-            else:
-                self.set_nested_key(key_list, {'secure': k})
-=======
             k = self.get_qualified_identifier(key.key_path)
-            CredentialManager.set(k, value)
-            self.set_nested_key(key.key_path, {'secure': k})
->>>>>>> no-str-creds
+            block_value = CredentialManager.set(k, value, *auto_encrypt)
+            if block_value is not None:
+                self.set_nested_key(key.key_path, pss(block_value))
+            else:
+                self.set_nested_key(key.key_path, {'secure': k})
             return k
 
     def retrieve_key(self, key):
         """
         Retrieves the value (if any) for key_list and returns the secure identifier if present
         If the key is not a secure key, returns None
-        :param key_list:
+        :param key:
         :return:
         """
         is_block = key.is_block
@@ -308,16 +297,8 @@ class UmapiCredentialConfig(CredentialConfig):
 
 class ConsoleCredentialConfig(CredentialConfig):
     secured_keys = [
-<<<<<<< HEAD
-        Credential(['integration', 'api_key']),
-        Credential(['integration', 'client_secret']),
-        Credential(['integration', 'priv_key_pass']),
-        Credential(['integration', 'priv_key_data'], is_block=True)
-    ]
-=======
         Key(key_path=['integration', 'api_key']),
         Key(key_path=['integration', 'client_secret']),
         Key(key_path=['integration', 'priv_key_pass']),
         Key(key_path=['integration', 'priv_key_data'], is_block=True)
     ]
->>>>>>> no-str-creds

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -57,7 +57,7 @@ class CredentialManager:
                                         " due to character limits.\n"
                                         "Encrypt private key instead? (y/n)".format(identifier, str(e)))
                 if response == 'y':
-                    result = cls.encrypt(value)
+                    return cls.encrypt(value)
                 else:
                     # not sure if necessary and if so what to do in this case
                     raise AssertionException("Private key will remain in plaintext, unencrypted format.")
@@ -184,8 +184,11 @@ class CredentialConfig:
             return
         if not self.parse_secure_key(value):
             k = self.get_qualified_identifier(key_list)
-            CredentialManager.set(k, value)
-            self.set_nested_key(key_list, {'secure': k})
+            value = CredentialManager.set(k, value)
+            if value is not None:
+                self.set_nested_key(key_list, pss(value))
+            else:
+                self.set_nested_key(key_list, {'secure': k})
             return k
 
     def retrieve_key(self, key_list):

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -1,5 +1,7 @@
+import binascii
 import logging
 from collections import Mapping
+from os import urandom
 
 import click
 import keyrings.cryptfile.cryptfile
@@ -68,7 +70,7 @@ class CredentialManager:
     @classmethod
     def encrypt(cls, data, *auto_encrypt):
         if auto_encrypt:
-            passphrase = 'notrandomyet'
+            passphrase = str(binascii.b2a_hex(urandom(16)).decode())
         else:
             passphrase = click.prompt('Create password ', hide_input=True, confirmation_prompt=True)
         return encryption.encrypt(passphrase, data)

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -55,7 +55,7 @@ class CredentialManager:
         except Exception as e:
             if "stub received bad data" in str(e):
                 # check that private key is in plaintext, unencrypted state?
-                if auto_encrypt:
+                if auto_encrypt[0]:
                     return cls.encrypt(value, *auto_encrypt)
                 else:
                     response = click.prompt("Bad value for '{0}': '{1}'. \nPrivate key storage may not be supported"

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -61,7 +61,6 @@ class CredentialManager:
                 else:
                     # not sure if necessary and if so what to do in this case
                     raise AssertionException("Private key will remain in plaintext, unencrypted format.")
-            raise e
 
     @classmethod
     def encrypt(cls, data):

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -117,13 +117,13 @@ class CredentialConfig:
 
     def modify_credentials(self, action):
         credentials = {}
-        for c in self.secured_keys:
+        for k in self.secured_keys:
             try:
                 # Try to do the action, but don't break on exception because rest of actions
                 # can still be completed
-                val = action(c)
+                val = action(k)
                 if val is not None:
-                    credentials[':'.join(c.credential)] = val
+                    credentials[':'.join(k.key_path)] = val
             except AssertionException as e:
                 logging.getLogger().exception("\nError: {}\n".format(str(e)), exc_info=False)
         return credentials
@@ -159,7 +159,7 @@ class CredentialConfig:
         """
         return self.filename + ":" + ":".join(identifier)
 
-    def store_key(self, key_list):
+    def store_key(self, key):
         """
         Takes a list of keys representing the path to a value in the YAML file, and constructs an identifier.
         If the key is a string and NOT in secure format, calls credential manager to set the key
@@ -167,26 +167,24 @@ class CredentialConfig:
         :param key_list: list of nested keys from a YAML file
         :return:
         """
-        key_list = ConfigLoader.as_list(key_list.credential)
-        value = self.get_nested_key(key_list)
+        value = self.get_nested_key(key.key_path)
         if value is None:
             return
         if not self.parse_secure_key(value):
-            k = self.get_qualified_identifier(key_list)
+            k = self.get_qualified_identifier(key.key_path)
             CredentialManager.set(k, value)
-            self.set_nested_key(key_list, {'secure': k})
+            self.set_nested_key(key.key_path, {'secure': k})
             return k
 
-    def retrieve_key(self, key_list):
+    def retrieve_key(self, key):
         """
         Retrieves the value (if any) for key_list and returns the secure identifier if present
         If the key is not a secure key, returns None
         :param key_list:
         :return:
         """
-        is_block = key_list.is_block
-        key_list = ConfigLoader.as_list(key_list.credential)
-        secure_identifier = self.parse_secure_key(self.get_nested_key(key_list))
+        is_block = key.is_block
+        secure_identifier = self.parse_secure_key(self.get_nested_key(key.key_path))
         if secure_identifier is None:
             return
         value = CredentialManager.get(secure_identifier)
@@ -196,10 +194,10 @@ class CredentialConfig:
             return value
         raise AssertionException("No stored value found for identifier: {}".format(secure_identifier))
 
-    def revert_key(self, key_list):
-        stored_credential = self.retrieve_key(key_list)
+    def revert_key(self, key):
+        stored_credential = self.retrieve_key(key)
         if stored_credential is not None:
-            self.set_nested_key(key_list.credential, stored_credential)
+            self.set_nested_key(key.key_path, stored_credential)
         return stored_credential
 
     @classmethod
@@ -243,34 +241,33 @@ class CredentialConfig:
         return d
 
 
-class Credential:
-    def __init__(self, credential, is_block=False):
-        self.credential = credential
+class Key:
+    def __init__(self, key_path, is_block=False):
+        self.key_path = key_path
         self.is_block = is_block
 
 
 class LdapCredentialConfig(CredentialConfig):
-    secured_keys = [Credential(['password'])]
+    secured_keys = [Key(key_path=['password'])]
 
 
 class OktaCredentialConfig(CredentialConfig):
-    secured_keys = [Credential(['api_token'])]
+    secured_keys = [Key(key_path=['api_token'])]
 
 
 class UmapiCredentialConfig(CredentialConfig):
     secured_keys = [
-        Credential(['enterprise', 'api_key']),
-        Credential(['enterprise', 'client_secret']),
-        Credential(['enterprise', 'priv_key_pass']),
-        Credential(['enterprise', 'priv_key_data'], is_block=True)
+        Key(key_path=['enterprise', 'api_key']),
+        Key(key_path=['enterprise', 'client_secret']),
+        Key(key_path=['enterprise', 'priv_key_pass']),
+        Key(key_path=['enterprise', 'priv_key_data'], is_block=True)
     ]
 
 
 class ConsoleCredentialConfig(CredentialConfig):
     secured_keys = [
-        Credential(['integration', 'api_key']),
-        Credential(['integration', 'client_secret']),
-        Credential(['integration', 'priv_key_pass']),
-        Credential(['integration', 'priv_key_data'], is_block=True)
+        Key(key_path=['integration', 'api_key']),
+        Key(key_path=['integration', 'client_secret']),
+        Key(key_path=['integration', 'priv_key_pass']),
+        Key(key_path=['integration', 'priv_key_data'], is_block=True)
     ]
-


### PR DESCRIPTION
When private key storage fails on Windows, the error will be handled by prompting the user to encrypt the private key data instead. If the user answers "y," they will be prompted for a password and then the key will be encrypted and the value of priv_key_data updated to the new encrypted key. If they answer "no," no action is taken and the private key will remain in a plaintext, unecrypted state.

User can bypass the prompts for encryption with the `--autoencrypt` or `-a` flag, which will automatically encrypt the private key with a randomly generated password. To make this flag work I had to add autoencrypt as an optional positional argument in all of the relevant CredentialManager and CredentialConfig methods.

I had to update one test to account bypass the prompts and then check for an exception. In this case the exception is coming from the encrypt method and not the set method.

I had to update umapi_util.py to decrypt key data within the yaml since it was set up to only decrypt if given a file path.