### PR TITLE
Credential manager - logic + abstraction

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -4,7 +4,6 @@ import uuid
 import pytest
 
 from user_sync.credentials import *
-from user_sync.error import AssertionException
 
 
 @pytest.fixture

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -485,14 +485,16 @@ def log_credentials(credentials, show_values=False):
               nargs=1,
               default="all",
               metavar='all|ldap|umapi|okta|console')
-@click.option('--auto-encrypt', '-a', help='Automatically encrypt private key data if storage fails.'
-                                           ' Passphrase will be randomly generated', is_flag=True)
-def store(config_filename, type, auto_encrypt):
+@click.option('--auto', '-a', help='Override user input (encrypt private key data if storage fails, etc.', is_flag=True)
+def store(config_filename, type, auto):
     """
-    Stores secure credentials in the configuration file. This is an automated process.
+    Stores secure credentials in the configuration file.
+    Use the --type parameter to store for just one file type (ldap, umapi, etc)
+    Use the --auto flag to override user prompts.  If key storage fails, it will be automatically encrypted with a
+    random passphrase, which will be stored in the credential manager instead.
     """
     click.echo()
-    stored = CredentialManager(config_filename, type).store(auto_encrypt)
+    stored = CredentialManager(config_filename, connector_type=type, auto=auto).store()
     if stored:
         click.echo("The following keys were stored:")
         log_credentials(stored)

--- a/user_sync/connector/umapi_util.py
+++ b/user_sync/connector/umapi_util.py
@@ -39,8 +39,6 @@ def make_auth_dict(name, config, org_id, tech_acct, logger):
         try:
             # try to decrypt the private key data within the file first
             key_data = decrypt(passphrase, key_data)
-            if key_data is None:
-                key_data = decrypt(passphrase, key_path)
         except (ValueError, IndexError, TypeError, AssertionException) as e:
             raise AssertionException('%s: Error decrypting private key, either the password is wrong or: %s' %
                                      (config.get_full_scope(), e))

--- a/user_sync/encryption.py
+++ b/user_sync/encryption.py
@@ -53,3 +53,12 @@ def decrypt(passphrase, data):
 
 def contains_phrase(result, *args):
     return True in {x.lower() in result.lower() for x in args}
+
+def is_encryptable(data):
+    try:
+        encrypt("pass", data)
+        return True
+    except Exception:
+        return False
+
+


### PR DESCRIPTION
- Move priv_key_pass to key class so as to abstract remaining literal piece of encryption storage - now it should work for any long or encryptable field(s), not just private key
- Add "linked_key" to key class - this indicates relationship between data and password keys - is optional.  It is used here to guide logic for encryption process and passphrase interaction.
- Other misc logical refactoring