### PR TITLE
Include details from request response in error message 

### DIFF
--- a/tests/test_post_sync.py
+++ b/tests/test_post_sync.py
@@ -1,4 +1,14 @@
+import json
+from unittest import mock
+from unittest.mock import patch
+
 import pytest
+import requests
+from requests import Response
+from requests.exceptions import ConnectionError
+
+from user_sync.error import AssertionException
+from user_sync.post_sync.connectors.sign_sync import SignClient
 from user_sync.post_sync.manager import PostSyncData
 
 
@@ -51,3 +61,24 @@ def test_add_remove_groups(example_user):
     delta_groups = example_user['groups'] | set(groups_add)
     delta_groups -= set(groups_remove)
     assert post_sync_data.umapi_data[None][email_id]['groups'] == delta_groups
+
+@mock.patch('requests.get')
+@mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
+def test_base_uri_401_Unauthorized(mock_client, mock_get):
+    def mock_response(data):
+        r = Response()
+        r.status_code = 403
+        r.reason = 'Unauthorized'
+        return r
+
+    config = {
+            'console_org': None,
+            'host': 'api.na2.echosignstage.com',
+            'key': 'allsortsofgibberish1234567890',
+            'admin_email': 'admin@admin.com'
+    }
+    mock_get.return_value = mock_response({})
+    sc = SignClient(config)
+    sc.api_url = "example.com"
+    with pytest.raises(AssertionException):
+          sc.base_uri()

--- a/tests/test_post_sync.py
+++ b/tests/test_post_sync.py
@@ -62,23 +62,28 @@ def test_add_remove_groups(example_user):
     delta_groups -= set(groups_remove)
     assert post_sync_data.umapi_data[None][email_id]['groups'] == delta_groups
 
+
 @mock.patch('requests.get')
 @mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
-def test_base_uri_401_Unauthorized(mock_client, mock_get):
+def test_123(mock_client, mock_get):
     def mock_response(data):
         r = Response()
-        r.status_code = 403
+        # r.status_code = 401
         r.reason = 'Unauthorized'
+        r._content = json.dumps(data).encode()
         return r
 
     config = {
-            'console_org': None,
-            'host': 'api.na2.echosignstage.com',
-            'key': 'allsortsofgibberish1234567890',
-            'admin_email': 'admin@admin.com'
+        'console_org': None,
+        'host': 'api.na2.echosignstage.com',
+        'key': 'allsortsofgibberish1234567890',
+        'admin_email': 'admin@admin.com'
     }
-    mock_get.return_value = mock_response({})
+    # mock_get.status_code = 401
+    mock_get.return_value = mock_response({'status_code': 200})
+    # mock_get.side_effect = mock_response()
     sc = SignClient(config)
     sc.api_url = "example.com"
+
     with pytest.raises(AssertionException):
-          sc.base_uri()
+        sc.base_uri()

--- a/tests/test_post_sync.py
+++ b/tests/test_post_sync.py
@@ -65,12 +65,10 @@ def test_add_remove_groups(example_user):
 
 @mock.patch('requests.get')
 @mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
-def test_123(mock_client, mock_get):
+def test_assertion_exception_sucess(mock_client, mock_get):
     def mock_response(data):
         r = Response()
-        # r.status_code = 401
-        r.reason = 'Unauthorized'
-        r._content = json.dumps(data).encode()
+        r.status_code = 400
         return r
 
     config = {
@@ -79,11 +77,16 @@ def test_123(mock_client, mock_get):
         'key': 'allsortsofgibberish1234567890',
         'admin_email': 'admin@admin.com'
     }
-    # mock_get.status_code = 401
-    mock_get.return_value = mock_response({'status_code': 200})
-    # mock_get.side_effect = mock_response()
+
+    mock_get.return_value = mock_response({})
     sc = SignClient(config)
     sc.api_url = "example.com"
 
     with pytest.raises(AssertionException):
         sc.base_uri()
+
+    with pytest.raises(AssertionException):
+        sc.get_users()
+
+    with pytest.raises(AssertionException):
+        sc.get_groups()

--- a/tests/test_post_sync.py
+++ b/tests/test_post_sync.py
@@ -66,10 +66,10 @@ def test_add_remove_groups(example_user):
 @mock.patch('requests.get')
 @mock.patch('user_sync.post_sync.connectors.sign_sync.client.SignClient._init')
 def test_assertion_exception_sucess(mock_client, mock_get):
-    def mock_response(data):
-        r = Response()
-        r.status_code = 400
-        return r
+
+    mock_response = Response()
+    mock_response.status_code = 400
+    mock_get.return_value = mock_response
 
     config = {
         'console_org': None,
@@ -78,7 +78,6 @@ def test_assertion_exception_sucess(mock_client, mock_get):
         'admin_email': 'admin@admin.com'
     }
 
-    mock_get.return_value = mock_response({})
     sc = SignClient(config)
     sc.api_url = "example.com"
 

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -78,9 +78,8 @@ class SignClient:
         result = requests.get(url + url_path, headers=self.header())
         if result.status_code != 200:
             raise AssertionException(
-                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format(
-                    result.status_code,
-                    result.reason))
+                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format
+                (result.status_code, result.reason))
 
         if access_point_key not in result.json():
             raise AssertionException("Error getting base URI for Sign API, result invalid")

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -79,7 +79,7 @@ class SignClient:
         if result.status_code != 200:
             raise AssertionException(
                 "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format
-                (result.status_code, result.reason))
+                (result.status_code, result.content))
 
         if access_point_key not in result.json():
             raise AssertionException("Error getting base URI for Sign API, result invalid")
@@ -101,12 +101,12 @@ class SignClient:
         if users_res.status_code != 200:
             raise AssertionException(
                 "Error retrieving Sign user list, (error: {}, reason: {})".format(users_res.status_code,
-                                                                                  users_res.reason))
+                                                                                  users_res.content.decode()))
         for user_id in map(lambda u: u['userId'], users_res.json()['userInfoList']):
             user_res = requests.get(self.api_url + 'users/' + user_id, headers=self.header())
             if users_res.status_code != 200:
                 raise AssertionException("Error retrieving details for Sign user '{}'(error: {}, reason: {})".format
-                                         (user_id, users_res.status_code, users_res.reason))
+                                         (user_id, users_res.status_code, users_res.content.decode()))
             user = user_res.json()
             if user['userStatus'] != 'ACTIVE':
                 continue
@@ -130,7 +130,7 @@ class SignClient:
         res = requests.get(self.api_url + 'groups', headers=self.header())
         if res.status_code != 200:
             raise AssertionException("Error retrieving Sign group list(error: {}, reason: {})".format(res.status_code,
-                                                                                                      res.reason))
+                                                                                                      res.content.decode()))
         groups = {}
         sign_groups = res.json()
         for group in sign_groups['groupInfoList']:

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -78,8 +78,9 @@ class SignClient:
         result = requests.get(url + url_path, headers=self.header())
         if result.status_code != 200:
             raise AssertionException(
-                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format(result.status_code,
-                                                                                          result.reason))
+                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format(
+                    result.status_code,
+                    result.reason))
 
         if access_point_key not in result.json():
             raise AssertionException("Error getting base URI for Sign API, result invalid")
@@ -99,12 +100,14 @@ class SignClient:
         users_res = requests.get(self.api_url + 'users', headers=self.header())
 
         if users_res.status_code != 200:
-            raise AssertionException("Error retrieving Sign user list, (error: {}, reason: {})".format(users_res.status_code,
-                                                                                     users_res.reason))
+            raise AssertionException(
+                "Error retrieving Sign user list, (error: {}, reason: {})".format(users_res.status_code,
+                                                                                  users_res.reason))
         for user_id in map(lambda u: u['userId'], users_res.json()['userInfoList']):
             user_res = requests.get(self.api_url + 'users/' + user_id, headers=self.header())
             if users_res.status_code != 200:
-                raise AssertionException("Error retrieving details for Sign user '{}'".format(user_id))
+                raise AssertionException("Error retrieving details for Sign user '{}'(error: {}, reason: {})".format
+                                         (user_id, users_res.status_code, users_res.reason))
             user = user_res.json()
             if user['userStatus'] != 'ACTIVE':
                 continue
@@ -127,7 +130,8 @@ class SignClient:
 
         res = requests.get(self.api_url + 'groups', headers=self.header())
         if res.status_code != 200:
-            raise AssertionException("Error retrieving Sign group list")
+            raise AssertionException("Error retrieving Sign group list(error: {}, reason: {})".format(res.status_code,
+                                                                                                      res.reason))
         groups = {}
         sign_groups = res.json()
         for group in sign_groups['groupInfoList']:

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -77,7 +77,9 @@ class SignClient:
 
         result = requests.get(url + url_path, headers=self.header())
         if result.status_code != 200:
-            raise AssertionException("Error getting base URI from Sign API, is API key valid?")
+            raise AssertionException(
+                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format(result.status_code,
+                                                                                          result.reason))
 
         if access_point_key not in result.json():
             raise AssertionException("Error getting base URI for Sign API, result invalid")
@@ -97,7 +99,8 @@ class SignClient:
         users_res = requests.get(self.api_url + 'users', headers=self.header())
 
         if users_res.status_code != 200:
-            raise AssertionException("Error retrieving Sign user list")
+            raise AssertionException("Error retrieving Sign user list, (error: {}, reason: {})".format(users_res.status_code,
+                                                                                     users_res.reason))
         for user_id in map(lambda u: u['userId'], users_res.json()['userInfoList']):
             user_res = requests.get(self.api_url + 'users/' + user_id, headers=self.header())
             if users_res.status_code != 200:

--- a/user_sync/post_sync/connectors/sign_sync/client.py
+++ b/user_sync/post_sync/connectors/sign_sync/client.py
@@ -78,8 +78,8 @@ class SignClient:
         result = requests.get(url + url_path, headers=self.header())
         if result.status_code != 200:
             raise AssertionException(
-                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {})".format
-                (result.status_code, result.content))
+                "Error getting base URI from Sign API, is API key valid? (error: {}, reason: {}, {})".format
+                (result.status_code, result.reason, result.content))
 
         if access_point_key not in result.json():
             raise AssertionException("Error getting base URI for Sign API, result invalid")
@@ -100,13 +100,13 @@ class SignClient:
 
         if users_res.status_code != 200:
             raise AssertionException(
-                "Error retrieving Sign user list, (error: {}, reason: {})".format(users_res.status_code,
-                                                                                  users_res.content.decode()))
+                "Error retrieving Sign user list, (error: {}, reason: {}, {})".format(
+                    users_res.status_code, users_res.reason, users_res.content))
         for user_id in map(lambda u: u['userId'], users_res.json()['userInfoList']):
             user_res = requests.get(self.api_url + 'users/' + user_id, headers=self.header())
             if users_res.status_code != 200:
-                raise AssertionException("Error retrieving details for Sign user '{}'(error: {}, reason: {})".format
-                                         (user_id, users_res.status_code, users_res.content.decode()))
+                raise AssertionException("Error retrieving details for Sign user '{}'(error: {}, reason: {}, {})".format
+                                         (user_id, users_res.status_code, users_res.reason, users_res.content))
             user = user_res.json()
             if user['userStatus'] != 'ACTIVE':
                 continue
@@ -129,8 +129,8 @@ class SignClient:
 
         res = requests.get(self.api_url + 'groups', headers=self.header())
         if res.status_code != 200:
-            raise AssertionException("Error retrieving Sign group list(error: {}, reason: {})".format(res.status_code,
-                                                                                                      res.content.decode()))
+            raise AssertionException("Error retrieving Sign group list(error: {}, reason: {}, {})".format(
+                res.status_code, res.reason, res.content))
         groups = {}
         sign_groups = res.json()
         for group in sign_groups['groupInfoList']:


### PR DESCRIPTION
Will display content from request response for error messages if anything other than a success occurs for base URI, getting a list of users, getting a single user,  or getting a group of users. 