### PR TITLE
Rearrange example umapi config file to avoid ruamel comment bug

### DIFF
--- a/examples/config files - basic/connector-umapi.yml
+++ b/examples/config files - basic/connector-umapi.yml
@@ -51,6 +51,12 @@ server:
 # To use this feature, You can secure the credentials by using the credentials store command in the command line
 # Refer to the (URL to Additional Tools)
 
+# (optional) You can encrypt the private key by running `user-sync.exe encrypt'.  
+# This will encrypt the private key as RSA 256. you should uncomment 
+# priv_key_pass key so that User Sync is knows to decrypt the key.  priv_key_pass should have the plaintext value
+# of the password (or, see credential storage above).  The decryption also works for keys encrypted
+# externally with OpenSSL or other libraries, provided the format is correct.
+
 enterprise:
   org_id: "Org ID goes here"
   api_key: "API key goes here"
@@ -63,7 +69,7 @@ enterprise:
   # data directly in this file.  To do this, remove the priv_key_path entry above 
   # and uncomment the following entry.  Replace the sample data with the data 
   # from your private key file (which will be much longer).
-  # Note: the Windows credential store generally can't store data as large as a private
+  # Note: the Windows credential store can't store data as large as a private
   # key, so Windows users will be prompted to encrypt the private key data instead.
   #priv_key_data: |
   #   -----BEGIN RSA PRIVATE KEY-----

--- a/examples/config files - basic/connector-umapi.yml
+++ b/examples/config files - basic/connector-umapi.yml
@@ -44,38 +44,30 @@ server:
 # the correct settings for your enterprise organization.
 # [NOTE: the priv_key_path setting can be an absolute or relative pathname;
 # if relative, it is interpreted relative to this configuration file.]
+
+# (optional) You can store credentials in the operating system credential store
+# (Windows Credential Manager, Mac Keychain, Linux Freedesktop Secret Service
+# or KWallet - these will be built into the Linux distribution).
+# To use this feature, You can secure the credentials by using the credentials store command in the command line
+# Refer to the (URL to Additional Tools)
+
 enterprise:
   org_id: "Org ID goes here"
   api_key: "API key goes here"
   client_secret: "Client secret goes here"
   tech_acct: "Tech account ID goes here"
   priv_key_path: "private.key"
+  # priv_key_pass: "my passphrase for my private key"
 
   # (optional) As an alternative to priv_key_path, you can place the private key 
   # data directly in this file.  To do this, remove the priv_key_path entry above 
   # and uncomment the following entry.  Replace the sample data with the data 
   # from your private key file (which will be much longer).
+  # Note: the Windows credential store generally can't store data as large as a private
+  # key, so Windows users will be prompted to encrypt the private key data instead.
   #priv_key_data: |
   #   -----BEGIN RSA PRIVATE KEY-----
   #   MIIf74jfd84oAgEA6brj4uZ2f1Nkf84j843jfjjJGHYJ8756GHHGGz7jLyZWSscH
   #   CoifurKJY763GHKL98mJGYxWSBvhlWskdjdatagoeshere986fKFUNGd74kdfuEH
   #   -----END RSA PRIVATE KEY-----
-
-  # (optional) You can store credentials in the operating system credential store
-  # (Windows Credential Manager, Mac Keychain, Linux Freedesktop Secret Service
-  # or KWallet - these will be built into the Linux distribution).
-  # To use this feature, You can secure the credentials by using the credentials store commands in the command line
-
-  # Refer to the (URL to Additional Tools) 
-  # secure_priv_key_data_key: umapi_private_key_data
-  # Note: the Windows credential store generally can't store data as large as a private
-  # key, so the recommended path for securing your private key on windows is given next.
-
-  # (optional): You can secure your private key data by encrypting it, as with
-  #     openssl pkcs8 -in private.key -topk8 -v2 des3 -out private-encrypted.key
-  # which prompts for a passphrase and creates a passphrase-encrypted file in PKCS#8 format.
-  # Having done this, you can use the setting priv_key_pass to specify the passphrase needed
-  # by User Sync to decrypt the private key file (or private key data), as in:
-  # priv_key_pass: "my passphrase for my private key"
-  # Private key pass can also be stored using credentials store command
 

--- a/examples/config files - basic/connector-umapi.yml
+++ b/examples/config files - basic/connector-umapi.yml
@@ -57,7 +57,7 @@ enterprise:
   client_secret: "Client secret goes here"
   tech_acct: "Tech account ID goes here"
   priv_key_path: "private.key"
-  # priv_key_pass: "my passphrase for my private key"
+  #priv_key_pass: "my passphrase for my private key"
 
   # (optional) As an alternative to priv_key_path, you can place the private key 
   # data directly in this file.  To do this, remove the priv_key_path entry above 


### PR DESCRIPTION
I removed comments in the examples/connector-umapi.yml file that referred to the old secure key format and openSSL since both of these things will be irrelevant once the new features are merged. I rearranged the remaining keys and comments so that priv_key_data appears last and has no comments following it. This ensures that no comments will be lost in the credential storage/revert workflow.