### PR TITLE
get key data when stored in secure dict format

### DIFF
--- a/tests/test_umapi_util.py
+++ b/tests/test_umapi_util.py
@@ -45,3 +45,11 @@ def test_make_auth_dict(umapi_config_file, private_key):
     umapi_config['enterprise']['priv_key_data'] = None
     auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
     assert auth_dict['private_key_data'] == 'keydata'
+    # clear out old format (already tested for the exception if both are provided)
+    umapi_config['enterprise']['secure_priv_key_data_key'] = None
+    # put the regular priv_key_data back in the file and store
+    # the first 256 chars so it'll work without cryptfile on Windows
+    umapi_config['enterprise']['priv_key_data'] = {'secure': 'truncated_key_data'}
+    credman.set('truncated_key_data', key_data_from_file[:255])
+    auth_dict = make_auth_dict(name, umapi_dict_config, org_id_from_file, tech_acct_from_file, logger)
+    assert auth_dict['private_key_data'] == key_data_from_file[:255]


### PR DESCRIPTION
This PR allows a UST with priv_key_data stored in the secure dict format (as it would be after a successful run of `credentials store` on Linux or using Cryptfile) to successfully pull that data into the auth_dict to connect to UMAPI. I refactored the make_auth_dict method to call a separate method to get key data. The PR also includes additional assertions in the test of the umapi_util method for the secure dict scenario.