### PR TITLE
Bug Fix-adobe-only-user-list with with post sync

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -397,7 +397,7 @@ def begin_work(config_loader):
     post_sync_manager = None
     # get post-sync config unconditionally so we don't get an 'unused key' error
     post_sync_config = config_loader.get_post_sync_options()
-    if rule_config['strategy'] == 'sync':
+    if rule_config['strategy'] == 'sync' and directory_connector_module_name is not None:
         if post_sync_config:
             post_sync_manager = PostSyncManager(post_sync_config, rule_config['test_mode'])
             rule_config['extended_attributes'] |= post_sync_manager.get_directory_attributes()

--- a/user_sync/post_sync/manager.py
+++ b/user_sync/post_sync/manager.py
@@ -83,7 +83,7 @@ class PostSyncData:
 
     def remove_umapi_user(self, org_id, user_key):
         umapi_data = self.umapi_data.get(org_id)
-        if user_key not in umapi_data:
+        if umapi_data is None or user_key not in umapi_data:
             return
         del umapi_data[user_key]
 


### PR DESCRIPTION
If Adobe only user list is used a none type exception was thrown with post sync. Fix was to handle exception if  adobe-only-users- list used. Fixed to handle exception: "Post-Sync Connectors only support "sync" strategy".