### PR TITLE
Decrypt with revert

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -87,8 +87,7 @@ def test_retrieve_revert_ldap_invalid(tmp_config_files):
     assert creds == {}
 
 
-
-def test_retrieve_revert_umapi_valid(tmp_config_files):
+def test_retrieve_revert_umapi_valid(tmp_config_files, private_key):
     (_, _, umapi_config_file) = tmp_config_files
     umapi = UmapiCredentialConfig(umapi_config_file)
     # Using the api_key for assertions. The rest can be added in later if deemed necessary

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -105,6 +105,7 @@ def test_retrieve_revert_ldap_invalid(tmp_config_files):
 
 def test_retrieve_revert_umapi_valid(private_key, modify_umapi_config):
     umapi_config_file = modify_umapi_config(['enterprise', 'priv_key_path'], private_key)
+    umapi_config_file = modify_umapi_config(['enterprise', 'priv_key_pass'], 'password')
     umapi = UmapiCredentialConfig(umapi_config_file)
     # Using the api_key for assertions. The rest can be added in later if deemed necessary
     assert not umapi.parse_secure_key(umapi.get_nested_key(['enterprise', 'api_key']))
@@ -124,7 +125,7 @@ def test_retrieve_revert_umapi_valid(private_key, modify_umapi_config):
 def test_credman_retrieve_revert_valid(tmp_config_files, private_key, modify_umapi_config):
     (root_config_file, ldap_config_file, _) = tmp_config_files
     umapi_config_file = modify_umapi_config(['enterprise', 'priv_key_path'], private_key)
-    credman = CredentialManager(root_config_file)
+    credman = CredentialManager(root_config_file, auto=True)
     with open(ldap_config_file) as f:
         data = yaml.load(f)
         plaintext_ldap_password = data['password']

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -150,7 +150,10 @@ class CredentialConfig:
                 credentials[':'.join(label)] = val
         if isinstance(self, UmapiCredentialConfig):
             if self.get_nested_key(self.priv_key_path.key_path) is not None:
-                result = action(self.priv_key_path)
+                try:
+                    result = action(self.priv_key_path)
+                except AssertionException as e:
+                    self.logger.exception("\nError: {}\n".format(str(e)), exc_info=False)
         return credentials
 
     def store(self):
@@ -230,7 +233,7 @@ class CredentialConfig:
         return passphrase, key.key_path
 
     def decrypt_key(self, key):
-        if not key.has_linked():
+        if self.get_nested_key(key.linked_key.key_path) is None:
             raise AssertionException(
                 "Cannot decrypt key '{}'. Missing linked key '{}'".format(key.key_path, key.linked_key.key_path))
         value = self.get_nested_key(key.key_path)

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -201,7 +201,11 @@ class CredentialConfig:
             return
         if key.is_filepath:
             if self.auto or click.confirm("Encrypt private key file?"):
-                return self.encrypt_key(key)
+                enc_key = self.encrypt_key(key)
+                self.logger.info("Encrypted private key file saved to: '{}' \n"
+                                 "'{}' added to '{}' and stored securely."
+                                 .format(self.get_nested_key(key.key_path), key.linked_key.key_path, self.filename))
+                return enc_key
             else:
                 return
         if not self.parse_secure_key(value):
@@ -278,10 +282,14 @@ class CredentialConfig:
             if not encryption.is_encryptable(self.get_nested_key(key.key_path)):
                 decrypted_key = self.decrypt_key(key)
                 if decrypted_key is not None:
+                    self.logger.info("Private key file decrypted and saved to: '{}'"
+                                     .format(self.get_nested_key(key.key_path)))
                     self.set_nested_key(key.key_path, pss(decrypted_key))
         if key.is_filepath:
             decrypted_key = self.decrypt_key(key)
             if decrypted_key is not None:
+                self.logger.info("Private key file decrypted and saved to: '{}'"
+                                 .format(self.get_nested_key(key.key_path)))
                 encryption.write_key(decrypted_key, self.get_nested_key(key.key_path))
         return stored_credential
 

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -149,7 +149,7 @@ class CredentialConfig:
             if val is not None:
                 credentials[':'.join(label)] = val
         if isinstance(self, UmapiCredentialConfig):
-            if self.priv_key_path is not None:
+            if self.get_nested_key(self.priv_key_path.key_path) is not None:
                 result = action(self.priv_key_path)
         return credentials
 

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -200,7 +200,10 @@ class CredentialConfig:
         if value is None:
             return
         if key.is_filepath:
-            return self.encrypt_key(key)
+            if self.auto or click.confirm("Encrypt private key file?"):
+                return self.encrypt_key(key)
+            else:
+                return
         if not self.parse_secure_key(value):
             k = self.get_qualified_identifier(key.key_path)
             CredentialManager.set(k, value)

--- a/user_sync/credentials.py
+++ b/user_sync/credentials.py
@@ -148,6 +148,9 @@ class CredentialConfig:
 
             if val is not None:
                 credentials[':'.join(label)] = val
+        if isinstance(self, UmapiCredentialConfig):
+            if self.priv_key_path is not None:
+                result = action(self.priv_key_path)
         return credentials
 
     def store(self):
@@ -191,7 +194,7 @@ class CredentialConfig:
         :return:
         """
         value = self.get_nested_key(key.key_path) or value
-        if value is None:
+        if value is None or key.is_filepath:
             return
         if not self.parse_secure_key(value):
             k = self.get_qualified_identifier(key.key_path)
@@ -221,7 +224,8 @@ class CredentialConfig:
 
     def decrypt_key(self, key):
         if not key.has_linked():
-            raise AssertionException("Cannot decrypt key '{}'. Missing linked key '{}'".format(key.key_path, key.linked_key.key_path))
+            raise AssertionException(
+                "Cannot decrypt key '{}'. Missing linked key '{}'".format(key.key_path, key.linked_key.key_path))
         value = self.get_nested_key(key.key_path)
         if key.is_filepath:
             with open(value, 'r') as f:


### PR DESCRIPTION
If the private key has been encrypted, either within connector-umapi.yml (priv_key_data) or at the filepath destination specified for priv_key_path, the credentials revert command will decrypt that key using the priv_key_pass. If no priv_key_pass has been put into connector-umapi, an error will be thrown.