### PR TITLE
Feature/sign config 2

### DIFF
--- a/examples/sign/sign-sync-config.yml
+++ b/examples/sign/sign-sync-config.yml
@@ -1,6 +1,6 @@
 # Sign API Connections
 sign_orgs:
-  - connector: connector-sign.yml
+  primary: connector-sign.yml
   
 # Similar to "directory_users.connectors" in user-sync-config.yml
 identity_source:

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(name='user-sync',
           'umapi-client>=2.14',
           'click',
           'click-default-group',
-          'configparser==3.7.4'
+          'configparser==3.7.4',
+          'schema==0.7.2',
       ],
       extras_require={
           ':sys_platform=="linux" or sys_platform=="linux2"': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@ import shutil
 import pytest
 import yaml
 
-from tests.util import update_dict
-from user_sync.config.user_sync import ConfigLoader
+import shutil
+
+from user_sync.config.user_sync import UMAPIConfigLoader
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def cli_args():
         """
 
         args_out = {}
-        for k in ConfigLoader.invocation_defaults:
+        for k in UMAPIConfigLoader.invocation_defaults:
             args_out[k] = None
         for k, v in args_in.items():
             args_out[k] = v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import shutil
 
 from user_sync.config.user_sync import UMAPIConfigLoader
 
+from .util import update_dict
+
 
 @pytest.fixture
 def fixture_dir():
@@ -117,6 +119,16 @@ def modify_ldap_config(tmp_config_files):
         return ldap_config_file
 
     return _modify_ldap_config
+
+
+@pytest.fixture
+def sign_config_file(fixture_dir):
+    return os.path.join(fixture_dir, 'sign-sync-config.yml')
+
+
+@pytest.fixture
+def sign_connector_config(fixture_dir):
+    return os.path.join(fixture_dir, 'connector-sign.yml')
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,11 +66,6 @@ def root_config_file(fixture_dir):
 
 
 @pytest.fixture
-def sign_config_file(fixture_dir):
-    return os.path.join(fixture_dir, 'sign-sync-config.yml')
-
-
-@pytest.fixture
 def ldap_config_file(fixture_dir):
     return os.path.join(fixture_dir, 'connector-ldap.yml')
 

--- a/tests/fixture/connector-sign.yml
+++ b/tests/fixture/connector-sign.yml
@@ -1,3 +1,3 @@
 host: api.echosignstage.com
-key: [Sign API Key]
+key: "[Sign API Key]"
 admin_email: user@example.com

--- a/tests/fixture/sign-sync-config.yml
+++ b/tests/fixture/sign-sync-config.yml
@@ -1,6 +1,6 @@
 # Sign API Connections
 sign_orgs:
-  - connector: connector-sign.yml
+  primary: connector-sign.yml
   
 # Similar to "directory_users.connectors" in user-sync-config.yml
 identity_source:

--- a/tests/fixture/sign-sync-config.yml
+++ b/tests/fixture/sign-sync-config.yml
@@ -1,29 +1,44 @@
-identity_source:
-  connector: connector-ldap.yml
-  type: ldap
-invocation_defaults:
-  users: all
-logging:
-  console_log_level: debug
-  file_log_directory: sign_logs
-  file_log_level: info
-  file_log_name_format: '{:%Y-%m-%d}-sign.log'
-  log_to_file: true
+# Sign API Connections
 sign_orgs:
   primary: connector-sign.yml
-user_management:
-- admin_role: null
-  directory_group: Sign Users 1
-  sign_group: Group 1
-- admin_role: GROUP_ADMIN
-  directory_group: Sign Group Admins 1
-  sign_group: Group 1
-- admin_role: ACCOUNT_ADMIN
-  directory_group: Sign Admins
-  sign_group: null
-- admin_role: null
-  directory_group: Sign Normal Users
-  sign_group: null
+  
+# Similar to "directory_users.connectors" in user-sync-config.yml
+identity_source:
+  type: ldap
+  connector: connector-ldap.yml
+  
+# Options that govern the synchronization of users
 user_sync:
-  create_users: true
+  create_users: True
   sign_only_limit: 100
+ 
+# User management group/role mappings
+user_management:
+  # Example 1 - group assignment
+  - directory_group: Sign Users 1
+    sign_group: Group 1
+    admin_role:
+  # Example 2 - group admin assignment
+  - directory_group: Sign Group Admins 1
+    sign_group: Group 1
+    admin_role: GROUP_ADMIN
+  # Example 3 - account admin assignment
+  - directory_group: Sign Admins
+    sign_group:
+    admin_role: ACCOUNT_ADMIN
+  # Example 4 - create user if `create_users` is `True`, otherwise do nothing
+  - directory_group: Sign Normal Users
+    sign_group:
+    admin_role:
+  
+# Logging options
+logging:
+  log_to_file: True
+  file_log_directory: sign_logs
+  file_log_name_format: '{:%Y-%m-%d}-sign.log'
+  file_log_level: info
+  console_log_level: debug
+  
+# Defaults for options that can be passed as CLI options
+invocation_defaults:
+  users: mapped

--- a/tests/fixture/sign-sync-config.yml
+++ b/tests/fixture/sign-sync-config.yml
@@ -1,44 +1,29 @@
-# Sign API Connections
+identity_source:
+  connector: connector-ldap.yml
+  type: ldap
+invocation_defaults:
+  users: all
+logging:
+  console_log_level: debug
+  file_log_directory: sign_logs
+  file_log_level: info
+  file_log_name_format: '{:%Y-%m-%d}-sign.log'
+  log_to_file: true
 sign_orgs:
   primary: connector-sign.yml
-  
-# Similar to "directory_users.connectors" in user-sync-config.yml
-identity_source:
-  type: ldap
-  connector: connector-ldap.yml
-  
-# Options that govern the synchronization of users
-user_sync:
-  create_users: True
-  sign_only_limit: 100
- 
-# User management group/role mappings
 user_management:
-  # Example 1 - group assignment
-  - directory_group: Sign Users 1
-    sign_group: Group 1
-    admin_role:
-  # Example 2 - group admin assignment
-  - directory_group: Sign Group Admins 1
-    sign_group: Group 1
-    admin_role: GROUP_ADMIN
-  # Example 3 - account admin assignment
-  - directory_group: Sign Admins
-    sign_group:
-    admin_role: ACCOUNT_ADMIN
-  # Example 4 - create user if `create_users` is `True`, otherwise do nothing
-  - directory_group: Sign Normal Users
-    sign_group:
-    admin_role:
-  
-# Logging options
-logging:
-  log_to_file: True
-  file_log_directory: sign_logs
-  file_log_name_format: '{:%Y-%m-%d}-sign.log'
-  file_log_level: info
-  console_log_level: debug
-  
-# Defaults for options that can be passed as CLI options
-invocation_defaults:
-  users: mapped
+- admin_role: null
+  directory_group: Sign Users 1
+  sign_group: Group 1
+- admin_role: GROUP_ADMIN
+  directory_group: Sign Group Admins 1
+  sign_group: Group 1
+- admin_role: ACCOUNT_ADMIN
+  directory_group: Sign Admins
+  sign_group: null
+- admin_role: null
+  directory_group: Sign Normal Users
+  sign_group: null
+user_sync:
+  create_users: true
+  sign_only_limit: 100

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,12 +54,12 @@ def test_max_adobe_percentage(modify_root_config, cli_args, ust_config_root_path
             config['limits']['max_adobe_only_users'] == "50%")
 
     args = cli_args({'config_filename': root_config_file})
-    options = UMAPIConfigLoader(args).get_rule_options()
+    options = UMAPIConfigLoader(args).get_engine_options()
     assert 'max_adobe_only_users' in options and options['max_adobe_only_users'] == '50%'
 
     modify_root_config(['limits', 'max_adobe_only_users'], "error%")
     with pytest.raises(AssertionException):
-        UMAPIConfigLoader(args).get_rule_options()
+        UMAPIConfigLoader(args).get_engine_options()
 
 
 def test_additional_groups_config(modify_root_config, cli_args, ust_config_root_path_keys, ust_config_sub_path_keys):
@@ -74,7 +74,7 @@ def test_additional_groups_config(modify_root_config, cli_args, ust_config_root_
             len(config['directory_users']['additional_groups']) == 2)
 
     args = cli_args({'config_filename': root_config_file})
-    options = UMAPIConfigLoader(args).get_rule_options()
+    options = UMAPIConfigLoader(args).get_engine_options()
     assert addl_groups[0]['source'] in options['additional_groups'][0]['source'].pattern
     assert addl_groups[1]['source'] in options['additional_groups'][1]['source'].pattern
 
@@ -137,16 +137,11 @@ def test_extension_load(tmp_config_files, modify_root_config, cli_args, extensio
         (root_config_file, _, _) = tmp_config_files
 
         args = cli_args({'config_filename': root_config_file})
-        options = UMAPIConfigLoader(args).get_rule_options()
+        options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 
-<<<<<<< HEAD
-        modify_root_config(['directory_users', 'extension'], extension_config_file)
-        options = ConfigLoader(args).get_rule_options()
-=======
         modify_root_config(['directory_users', 'extension'], tmp_extension_config)
-        options = UMAPIConfigLoader(args).get_rule_options()
->>>>>>> rename ConfigLoader to UMAPIConfigLoader
+        options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is not None
 
 
@@ -158,13 +153,8 @@ def test_extension_flag(tmp_config_files, modify_root_config, cli_args, extensio
         (root_config_file, _, _) = tmp_config_files
 
         args = cli_args({'config_filename': root_config_file})
-<<<<<<< HEAD
-        modify_root_config(['directory_users', 'extension'], extension_config_file)
-        options = ConfigLoader(args).get_rule_options()
-=======
         modify_root_config(['directory_users', 'extension'], tmp_extension_config)
-        options = UMAPIConfigLoader(args).get_rule_options()
->>>>>>> rename ConfigLoader to UMAPIConfigLoader
+        options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,10 @@
 import pytest
-
-from user_sync import flags
+import yaml
+import shutil
+from util import update_dict
+from user_sync.config.user_sync import UMAPIConfigLoader
 from user_sync.config.common import ConfigFileLoader, DictConfig
-from user_sync.config.user_sync import ConfigLoader
+from user_sync import flags
 from user_sync.error import AssertionException
 
 
@@ -10,7 +12,7 @@ def load_ldap_config_options(args):
     from user_sync.connector.directory import DirectoryConnector
     from user_sync.connector.directory_ldap import LDAPDirectoryConnector
 
-    config_loader = ConfigLoader(args)
+    config_loader = UMAPIConfigLoader(args)
     dc_mod_name = config_loader.get_directory_connector_module_name()
     dc_mod = __import__(dc_mod_name, fromlist=[''])
     dc = DirectoryConnector(dc_mod)
@@ -52,12 +54,12 @@ def test_max_adobe_percentage(modify_root_config, cli_args, ust_config_root_path
             config['limits']['max_adobe_only_users'] == "50%")
 
     args = cli_args({'config_filename': root_config_file})
-    options = ConfigLoader(args).get_rule_options()
+    options = UMAPIConfigLoader(args).get_rule_options()
     assert 'max_adobe_only_users' in options and options['max_adobe_only_users'] == '50%'
 
     modify_root_config(['limits', 'max_adobe_only_users'], "error%")
     with pytest.raises(AssertionException):
-        ConfigLoader(args).get_rule_options()
+        UMAPIConfigLoader(args).get_rule_options()
 
 
 def test_additional_groups_config(modify_root_config, cli_args, ust_config_root_path_keys, ust_config_sub_path_keys):
@@ -72,7 +74,7 @@ def test_additional_groups_config(modify_root_config, cli_args, ust_config_root_
             len(config['directory_users']['additional_groups']) == 2)
 
     args = cli_args({'config_filename': root_config_file})
-    options = ConfigLoader(args).get_rule_options()
+    options = UMAPIConfigLoader(args).get_rule_options()
     assert addl_groups[0]['source'] in options['additional_groups'][0]['source'].pattern
     assert addl_groups[1]['source'] in options['additional_groups'][1]['source'].pattern
 
@@ -107,14 +109,14 @@ def test_adobe_users_config(tmp_config_files, modify_root_config, cli_args):
     args = cli_args({'config_filename': root_config_file})
 
     # test default
-    config_loader = ConfigLoader(args)
+    config_loader = UMAPIConfigLoader(args)
     options = config_loader.load_invocation_options()
     assert 'adobe_users' in options
     assert options['adobe_users'] == ['all']
 
     # test default invocation
     modify_root_config(['invocation_defaults', 'adobe_users'], "mapped")
-    config_loader = ConfigLoader(args)
+    config_loader = UMAPIConfigLoader(args)
     options = config_loader.load_invocation_options()
     assert 'adobe_users' in options
     assert options['adobe_users'] == ['mapped']
@@ -122,7 +124,7 @@ def test_adobe_users_config(tmp_config_files, modify_root_config, cli_args):
     # test command line param
     modify_root_config(['invocation_defaults', 'adobe_users'], "all")
     args = cli_args({'config_filename': root_config_file, 'adobe_users': ['mapped']})
-    config_loader = ConfigLoader(args)
+    config_loader = UMAPIConfigLoader(args)
     options = config_loader.load_invocation_options()
     assert 'adobe_users' in options
     assert options['adobe_users'] == ['mapped']
@@ -135,11 +137,16 @@ def test_extension_load(tmp_config_files, modify_root_config, cli_args, extensio
         (root_config_file, _, _) = tmp_config_files
 
         args = cli_args({'config_filename': root_config_file})
-        options = ConfigLoader(args).get_rule_options()
+        options = UMAPIConfigLoader(args).get_rule_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 
+<<<<<<< HEAD
         modify_root_config(['directory_users', 'extension'], extension_config_file)
         options = ConfigLoader(args).get_rule_options()
+=======
+        modify_root_config(['directory_users', 'extension'], tmp_extension_config)
+        options = UMAPIConfigLoader(args).get_rule_options()
+>>>>>>> rename ConfigLoader to UMAPIConfigLoader
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is not None
 
 
@@ -151,8 +158,13 @@ def test_extension_flag(tmp_config_files, modify_root_config, cli_args, extensio
         (root_config_file, _, _) = tmp_config_files
 
         args = cli_args({'config_filename': root_config_file})
+<<<<<<< HEAD
         modify_root_config(['directory_users', 'extension'], extension_config_file)
         options = ConfigLoader(args).get_rule_options()
+=======
+        modify_root_config(['directory_users', 'extension'], tmp_extension_config)
+        options = UMAPIConfigLoader(args).get_rule_options()
+>>>>>>> rename ConfigLoader to UMAPIConfigLoader
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 
 
@@ -167,7 +179,7 @@ def test_shell_exec_flag(tmp_config_files, modify_root_config, cli_args, monkeyp
         args = cli_args({'config_filename': root_config_file})
         modify_root_config(['directory_users', 'connectors', 'ldap'], "$(some command)")
         with pytest.raises(AssertionException):
-            config_loader = ConfigLoader(args)
+            config_loader = UMAPIConfigLoader(args)
 
             directory_connector_module_name = config_loader.get_directory_connector_module_name()
             if directory_connector_module_name is not None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 import shutil
-from util import update_dict
+from .util import update_dict
 from user_sync.config.user_sync import UMAPIConfigLoader
 from user_sync.config.common import ConfigFileLoader, DictConfig
 from user_sync import flags
@@ -140,7 +140,7 @@ def test_extension_load(tmp_config_files, modify_root_config, cli_args, extensio
         options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 
-        modify_root_config(['directory_users', 'extension'], tmp_extension_config)
+        modify_root_config(['directory_users', 'extension'], extension_config_file)
         options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is not None
 
@@ -153,7 +153,7 @@ def test_extension_flag(tmp_config_files, modify_root_config, cli_args, extensio
         (root_config_file, _, _) = tmp_config_files
 
         args = cli_args({'config_filename': root_config_file})
-        modify_root_config(['directory_users', 'extension'], tmp_extension_config)
+        modify_root_config(['directory_users', 'extension'], extension_config_file)
         options = UMAPIConfigLoader(args).get_engine_options()
         assert 'after_mapping_hook' in options and options['after_mapping_hook'] is None
 

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -1,12 +1,64 @@
 import logging
+import pytest
+import yaml
+from util import update_dict
 from user_sync.config.sign_sync import SignConfigLoader
 from user_sync.config.user_sync import DictConfig
 
 
+@pytest.fixture
+def modify_sign_config(sign_config_file):
+    def _modify_sign_config(keys, val):
+        conf = yaml.safe_load(open(sign_config_file))
+        conf = update_dict(conf, keys, val)
+        yaml.dump(conf, open(sign_config_file, 'w'))
+
+        return sign_config_file
+    return _modify_sign_config
+
+
 def test_loader_attributes(sign_config_file):
+    """ensure that initial load of Sign config is correct"""
     args = {'config_filename': sign_config_file}
     config = SignConfigLoader(args)
     assert isinstance(config.logger, logging.Logger)
     assert config.args == args
-    assert config.invocation_options == {'users': ['mapped']}
+    assert 'users' in config.invocation_options
+    assert 'config_filename' in config.invocation_options
     assert isinstance(config.main_config, DictConfig)
+
+
+def test_config_structure(sign_config_file):
+    """ensure that Sign config test fixture is structured correctly"""
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    assert 'sign_orgs' in config.main_config
+    assert 'primary' in config.main_config.get_dict('sign_orgs')
+    assert 'identity_source' in config.main_config
+    assert 'type' in config.main_config.get_dict('identity_source')
+    assert 'connector' in config.main_config.get_dict('identity_source')
+    assert 'user_sync' in config.main_config
+    assert 'create_users' in config.main_config.get_dict('user_sync')
+    assert 'sign_only_limit' in config.main_config.get_dict('user_sync')
+    assert 'user_management' in config.main_config
+    assert 'logging' in config.main_config
+    assert 'log_to_file' in config.main_config.get_dict('logging')
+    assert 'file_log_directory' in config.main_config.get_dict('logging')
+    assert 'file_log_name_format' in config.main_config.get_dict('logging')
+    assert 'file_log_level' in config.main_config.get_dict('logging')
+    assert 'console_log_level' in config.main_config.get_dict('logging')
+    assert 'invocation_defaults' in config.main_config
+    assert 'users' in config.main_config.get_dict('invocation_defaults')
+
+
+def test_invocation_defaults(modify_sign_config):
+    """ensure that invocation defaults are resolved correctly"""
+    sign_config_file = modify_sign_config(['invocation_defaults', 'users'], 'all')
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    assert 'users' in config.invocation_options
+    assert config.invocation_options['users'] == ['all']
+    args = {'config_filename': sign_config_file, 'users': ['some_option']}
+    config = SignConfigLoader(args)
+    assert 'users' in config.invocation_options
+    assert config.invocation_options['users'] == ['some_option']

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -3,22 +3,12 @@ import pytest
 import yaml
 import os
 import shutil
-from util import update_dict
+from .util import update_dict
 from user_sync.config.sign_sync import SignConfigLoader
 from user_sync.config.user_sync import DictConfig
 from user_sync.engine.common import AdobeGroup
 from user_sync.engine.sign import SignSyncEngine
 from user_sync.error import AssertionException
-
-
-@pytest.fixture
-def sign_config_file(fixture_dir):
-    return os.path.join(fixture_dir, 'sign-sync-config.yml')
-
-
-@pytest.fixture
-def sign_connector_config(fixture_dir):
-    return os.path.join(fixture_dir, 'connector-sign.yml')
 
 
 @pytest.fixture

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -7,6 +7,7 @@ from util import update_dict
 from user_sync.config.sign_sync import SignConfigLoader
 from user_sync.config.user_sync import DictConfig
 from user_sync.engine.common import AdobeGroup
+from user_sync.error import AssertionException
 
 
 @pytest.fixture
@@ -119,3 +120,17 @@ def test_identity_module(sign_config_file, modify_sign_config, tmp_sign_connecto
     args = {'config_filename': sign_config_file}
     config = SignConfigLoader(args)
     assert config.get_directory_connector_module_name() == 'user_sync.connector.directory_okta'
+
+
+def test_sign_connector_options(sign_config_file):
+    """ensure sign connector options are retrieved from Sign config handler"""
+    options = {'username': 'ldapuser@example.com', 'password': 'password', 'host': 'ldap://host', 'base_dn': 'DC=example,DC=com', 'search_page_size': 200,
+               'require_tls_cert': False, 'all_users_filter': '(&(objectClass=user)(objectCategory=person)(!(userAccountControl:1.2.840.113556.1.4.803:=2)))',
+               'group_filter_format': '(&(|(objectCategory=group)(objectClass=groupOfNames)(objectClass=posixGroup))(cn={group}))',
+               'group_member_filter_format': '(memberOf={group_dn})', 'user_email_format': '{mail}'}
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    assert config.get_directory_connector_options('ldap') == options
+
+    with pytest.raises(AssertionException):
+        config.get_directory_connector_options('okta')

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -60,24 +60,8 @@ def test_loader_attributes(sign_config_file):
 def test_config_structure(sign_config_file):
     """ensure that Sign config test fixture is structured correctly"""
     args = {'config_filename': sign_config_file}
-    config = SignConfigLoader(args)
-    assert 'sign_orgs' in config.main_config
-    assert 'primary' in config.main_config.get_dict('sign_orgs')
-    assert 'identity_source' in config.main_config
-    assert 'type' in config.main_config.get_dict('identity_source')
-    assert 'connector' in config.main_config.get_dict('identity_source')
-    assert 'user_sync' in config.main_config
-    assert 'create_users' in config.main_config.get_dict('user_sync')
-    assert 'sign_only_limit' in config.main_config.get_dict('user_sync')
-    assert 'user_management' in config.main_config
-    assert 'logging' in config.main_config
-    assert 'log_to_file' in config.main_config.get_dict('logging')
-    assert 'file_log_directory' in config.main_config.get_dict('logging')
-    assert 'file_log_name_format' in config.main_config.get_dict('logging')
-    assert 'file_log_level' in config.main_config.get_dict('logging')
-    assert 'console_log_level' in config.main_config.get_dict('logging')
-    assert 'invocation_defaults' in config.main_config
-    assert 'users' in config.main_config.get_dict('invocation_defaults')
+    _ = SignConfigLoader(args)
+    # nothing to assert here, if the config object is constructed without exceptions, then the test passes
 
 
 # NOTE: tmp_sign_connector_config and tmp_config_files are needed to prevent the ConfigFileLoader

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -175,3 +175,9 @@ def test_logging_config(sign_config_file):
     assert logging_config.get_string('file_log_name_format') == '{:%Y-%m-%d}-sign.log'
     assert logging_config.get_string('file_log_level') == 'info'
     assert logging_config.get_string('console_log_level') == 'debug'
+
+
+def test_engine_options(sign_config_file):
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -104,3 +104,18 @@ def test_group_config(modify_sign_config, tmp_sign_connector_config, tmp_config_
     assert 'Test Group 2' in group_mappings
     for mapping in group_mappings['Test Group 2']:
         assert mapping in [AdobeGroup.create('Sign Group 2'), AdobeGroup.create('Sign Group 3')]
+
+
+
+# NOTE: tmp_sign_connector_config and tmp_config_files are needed to prevent the ConfigFileLoader
+# from complaining that there are no temporary sign connector or ldap connector files
+def test_identity_module(sign_config_file, modify_sign_config, tmp_sign_connector_config, tmp_config_files):
+    """ensure directory module name is correct"""
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    assert config.get_directory_connector_module_name() == 'user_sync.connector.directory_ldap'
+
+    sign_config_file = modify_sign_config(['identity_source', 'type'], 'okta')
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    assert config.get_directory_connector_module_name() == 'user_sync.connector.directory_okta'

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -107,7 +107,6 @@ def test_group_config(modify_sign_config, tmp_sign_connector_config, tmp_config_
         assert mapping in [AdobeGroup.create('Sign Group 2'), AdobeGroup.create('Sign Group 3')]
 
 
-
 # NOTE: tmp_sign_connector_config and tmp_config_files are needed to prevent the ConfigFileLoader
 # from complaining that there are no temporary sign connector or ldap connector files
 def test_identity_module(sign_config_file, modify_sign_config, tmp_sign_connector_config, tmp_config_files):
@@ -134,3 +133,14 @@ def test_sign_connector_options(sign_config_file):
 
     with pytest.raises(AssertionException):
         config.get_directory_connector_options('okta')
+
+
+def test_logging_config(sign_config_file):
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    logging_config = config.get_logging_config()
+    assert logging_config.get_bool('log_to_file') is True
+    assert logging_config.get_string('file_log_directory').endswith('sign_logs')
+    assert logging_config.get_string('file_log_name_format') == '{:%Y-%m-%d}-sign.log'
+    assert logging_config.get_string('file_log_level') == 'info'
+    assert logging_config.get_string('console_log_level') == 'debug'

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,7 +4,7 @@ import collections
 def update_dict(d, ks, u):
     k, ks = ks[0], ks[1:]
     v = d.get(k)
-    if isinstance(v, collections.Mapping):
+    if len(ks) and isinstance(v, collections.Mapping):
         d[k] = update_dict(v, ks, u)
     else:
         d[k] = u

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -455,7 +455,7 @@ def begin_work(config_loader):
     :type config_loader: config.UMAPIConfigLoader
     """
     directory_groups = config_loader.get_directory_groups()
-    rule_config = config_loader.get_rule_options()
+    rule_config = config_loader.get_engine_options()
 
     # make sure that all the adobe groups are from known umapi connector names
     primary_umapi_config, secondary_umapi_configs = config_loader.get_target_options()

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -44,6 +44,7 @@ from user_sync.config import common as config_common
 from user_sync.config.sign_sync import SignConfigLoader
 from user_sync.connector.connector_umapi import UmapiConnector
 from user_sync.engine import umapi as rules
+from user_sync.engine.common import PRIMARY_TARGET_NAME
 
 from user_sync.post_sync.manager import PostSyncManager
 import user_sync.post_sync.connectors.sign_sync
@@ -462,7 +463,7 @@ def begin_work(config_loader):
     for groups in six.itervalues(directory_groups):
         for group in groups:
             umapi_name = group.umapi_name
-            if umapi_name != user_sync.engine.umapi.PRIMARY_UMAPI_NAME:
+            if umapi_name != PRIMARY_TARGET_NAME:
                 referenced_umapi_names.add(umapi_name)
     referenced_umapi_names.difference_update(six.iterkeys(secondary_umapi_configs))
     if len(referenced_umapi_names) > 0:

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -177,7 +177,7 @@ def sync(**kwargs):
         del(kwargs['sign_sync_config'])
     try:
         # load the config files and start the file logger
-        config_loader = config.ConfigLoader(kwargs)
+        config_loader = config.UMAPIConfigLoader(kwargs)
         init_log(config_loader.get_logging_config())
 
         # add start divider, app version number, and invocation parameters to log
@@ -437,7 +437,7 @@ def log_parameters(argv, config_loader):
     :param argv: command line arguments (a la sys.argv)
     :type argv: list(str)
     :param config_loader: the main configuration loader
-    :type config_loader: config.ConfigLoader
+    :type config_loader: config.UMAPIConfigLoader
     :return: None
     """
     logger.info('Python version: %s.%s.%s on %s' % (sys.version_info[:3] + (sys.platform,)))
@@ -451,7 +451,7 @@ def log_parameters(argv, config_loader):
 
 def begin_work(config_loader):
     """
-    :type config_loader: config.ConfigLoader
+    :type config_loader: config.UMAPIConfigLoader
     """
     directory_groups = config_loader.get_directory_groups()
     rule_config = config_loader.get_rule_options()

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -458,7 +458,7 @@ def begin_work(config_loader):
     rule_config = config_loader.get_rule_options()
 
     # make sure that all the adobe groups are from known umapi connector names
-    primary_umapi_config, secondary_umapi_configs = config_loader.get_umapi_options()
+    primary_umapi_config, secondary_umapi_configs = config_loader.get_target_options()
     referenced_umapi_names = set()
     for groups in six.itervalues(directory_groups):
         for group in groups:

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -3,11 +3,38 @@ import os
 
 import six
 import yaml
+from abc import ABC, abstractmethod
 
 import user_sync.helper
 import user_sync.identity_type
 import user_sync.port
 from user_sync.error import AssertionException
+
+
+class ConfigLoader(ABC):
+    @abstractmethod
+    def get_invocation_options(self):
+        pass
+
+    @abstractmethod
+    def get_directory_groups(self):
+        pass
+
+    @abstractmethod
+    def get_directory_connector_module_name(self):
+        pass
+
+    @abstractmethod
+    def get_directory_connector_options(self):
+        pass
+
+    @abstractmethod
+    def check_unused_config_keys(self):
+        pass
+
+    @abstractmethod
+    def get_logging_config(self):
+        pass
 
 
 class ObjectConfig:

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -29,6 +29,10 @@ class ConfigLoader(ABC):
         pass
 
     @abstractmethod
+    def get_target_options(self) -> (dict, dict):
+        pass
+
+    @abstractmethod
     def check_unused_config_keys(self):
         pass
 

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -21,6 +21,10 @@ class ConfigLoader(ABC):
         pass
 
     @abstractmethod
+    def get_engine_options(self) -> dict:
+        pass
+
+    @abstractmethod
     def get_directory_connector_module_name(self) -> str:
         pass
 

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -211,7 +211,7 @@ class DictConfig(ObjectConfig):
             value = [value]
         return value
 
-    def get_list_config(self, key, none_allowed=False):
+    def get_list_config(self, key, none_allowed=False) -> ListConfig:
         """
         :rtype ListConfig
         """

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -21,11 +21,11 @@ class ConfigLoader(ABC):
         pass
 
     @abstractmethod
-    def get_directory_connector_module_name(self):
+    def get_directory_connector_module_name(self) -> str:
         pass
 
     @abstractmethod
-    def get_directory_connector_options(self):
+    def get_directory_connector_options(self, name: str) -> dict:
         pass
 
     @abstractmethod

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -184,7 +184,7 @@ class DictConfig(ObjectConfig):
         value = self.get_value(key, dict, none_allowed)
         return value
 
-    def get_string(self, key, none_allowed=False):
+    def get_string(self, key, none_allowed=False) -> str:
         """
         :rtype: basestring
         """

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -507,3 +507,28 @@ class OptionsBuilder(object):
             raise AssertionException("No config found.")
         self.options[key] = value = config.get_value(key, allowed_types)
         return value
+        
+        
+def resolve_invocation_options(options: dict, invocation_config: DictConfig, invocation_defaults: dict, args: dict) -> dict:
+    # get overrides from the main config
+    if invocation_config:
+        for k, v in six.iteritems(invocation_defaults):
+            if isinstance(v, bool):
+                val = invocation_config.get_bool(k, True)
+                if val is not None:
+                    options[k] = val
+            elif isinstance(v, list):
+                val = invocation_config.get_list(k, True)
+                if val:
+                    options[k] = val
+            else:
+                val = invocation_config.get_string(k, True)
+                if val:
+                    options[k] = val
+
+    # now handle overrides from CLI options
+    for k, arg_val in args.items():
+        if arg_val is None:
+            continue
+        options[k] = arg_val
+    return options

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -10,7 +10,7 @@ import user_sync.port
 from user_sync.error import AssertionException
 
 
-class ObjectConfig(object):
+class ObjectConfig:
     def __init__(self, scope):
         """
         :type scope: str
@@ -452,7 +452,7 @@ class ConfigFileLoader:
         return val
 
 
-class OptionsBuilder(object):
+class OptionsBuilder:
     def __init__(self, default_config):
         """
         :type default_config: DictConfig

--- a/user_sync/config/error.py
+++ b/user_sync/config/error.py
@@ -1,0 +1,6 @@
+from user_sync.error import AssertionException
+
+
+class ConfigValidationError(AssertionException):
+    def __init__(self, message):
+        super(ConfigValidationError, self).__init__(message)

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -3,11 +3,11 @@ import codecs
 
 from copy import deepcopy
 
-from user_sync.config.common import DictConfig, ConfigFileLoader, resolve_invocation_options
+from user_sync.config.common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
 from user_sync.error import AssertionException
 
 
-class SignConfigLoader:
+class SignConfigLoader(ConfigLoader):
     """
     Loads config files and does pathname expansion on settings that refer to files or directories
     """
@@ -53,3 +53,21 @@ class SignConfigLoader:
         config_loader = ConfigFileLoader(config_encoding, self.ROOT_CONFIG_PATH_KEYS, self.SUB_CONFIG_PATH_KEYS)
         main_config_content = config_loader.load_root_config(config_filename)
         return DictConfig("<%s>" % config_filename, main_config_content)
+
+    def get_directory_groups(self):
+        pass
+
+    def get_directory_connector_module_name(self):
+        pass
+
+    def get_directory_connector_options(self):
+        pass
+
+    def check_unused_config_keys(self):
+        pass
+
+    def get_logging_config(self):
+        pass
+
+    def get_invocation_options(self):
+        pass

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -10,8 +10,33 @@ from .error import ConfigValidationError
 
 
 def config_schema() -> Schema:
-    from schema import And, Use, Optional, Or
-    return Schema({})
+    from schema import And, Use, Optional, Or, Regex
+    return Schema({
+        'sign_orgs': { str: str },
+        'identity_source': {
+            'connector': And(str, len),
+            'type': Or('csv', 'okta', 'ldap', 'adobe_console'),
+        },
+        'user_sync': {
+            'create_users': bool,
+            'sign_only_limit': Or(int, Regex(r'^\d+%$')),
+        },
+        'user_management': [{
+            'directory_group': Or(None, And(str, len)),
+            'sign_group': Or(None, And(str, len)),
+            'admin_role': Or(None, 'GROUP_ADMIN', 'ACCOUNT_ADMIN'),
+        }],
+        'logging': {
+            'log_to_file': bool,
+            'file_log_directory': And(str, len),
+            'file_log_name_format': And(str, len),
+            'file_log_level': Or('info', 'debug'), #TODO: what are the valid values here?
+            'console_log_level': Or('info', 'debug'), #TODO: what are the valid values here?
+        },
+        'invocation_defaults': {
+            'users': Or('mapped', 'all'),
+        }
+    })
 
 
 class SignConfigLoader(ConfigLoader):

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -146,6 +146,9 @@ class SignConfigLoader(ConfigLoader):
             secondary_options[target_id] = self.config_loader.load_sub_config(config_file)
         return primary_options, secondary_options
 
+    def get_engine_options(self) -> dict:
+        return {}
+
     def check_unused_config_keys(self):
         # not clear if we need this since we are validating the config schema
         pass

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -135,10 +135,11 @@ class SignConfigLoader(ConfigLoader):
         return self.config_loader.load_sub_config(source_config_path)
 
     def check_unused_config_keys(self):
+        # not clear if we need this since we are validating the config schema
         pass
 
-    def get_logging_config(self):
-        pass
+    def get_logging_config(self) -> DictConfig:
+        return self.main_config.get_dict_config('logging', True)
 
     def get_invocation_options(self):
         return self.invocation_options

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -9,6 +9,7 @@ from schema import Schema
 from user_sync.config.common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
 from user_sync.error import AssertionException
 from user_sync.engine.common import AdobeGroup
+from user_sync.engine.sign import SignSyncEngine
 from .error import ConfigValidationError
 
 
@@ -147,7 +148,13 @@ class SignConfigLoader(ConfigLoader):
         return primary_options, secondary_options
 
     def get_engine_options(self) -> dict:
-        return {}
+        options = deepcopy(SignSyncEngine.default_options)
+        options.update(self.invocation_options)
+
+        user_sync = self.main_config.get_dict_config('user_sync')
+        options['create_users'] = user_sync.get_bool('create_users')
+        options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
+        return options
 
     def check_unused_config_keys(self):
         # not clear if we need this since we are validating the config schema

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -120,10 +120,13 @@ class SignConfigLoader(ConfigLoader):
                 group_mapping[dir_group].append(group)
         return dict(group_mapping)
 
-    def get_directory_connector_module_name(self):
-        pass
+    def get_directory_connector_module_name(self) -> str:
+        # these .get()s can be safely chained because we've already validated the config schema
+        connector_type = self.main_config.get_dict('identity_source').get('type')
+        # we can also assume connector_type is valid, no need to check it
+        return 'user_sync.connector.directory_' + connector_type
 
-    def get_directory_connector_options(self):
+    def get_directory_connector_options(self, name: str) -> dict:
         pass
 
     def check_unused_config_keys(self):

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -13,12 +13,9 @@ class SignConfigLoader:
     """
     # key_paths in the root configuration file that should have filename values
     # mapped to their value options.  See load_from_yaml for the option meanings.
-    ROOT_CONFIG_PATH_KEYS = {'/adobe_users/connectors/umapi': (True, True, None),
-                             '/directory_users/connectors/*': (True, False, None),
-                             '/directory_users/extension': (True, False, None),
-                             '/logging/file_log_directory': (False, False, "logs"),
-                             '/post_sync/connectors/sign_sync': (False, False, False),
-                             '/post_sync/connectors/future_feature': (False, False, False)
+    ROOT_CONFIG_PATH_KEYS = {'/sign_orgs/*': (True, False, None),
+                             '/identity_source/connector': (True, False, None),
+                             '/logging/file_log_directory': (False, False, "sign_logs"),
                              }
 
     # like ROOT_CONFIG_PATH_KEYS, but for non-root configuration files

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -1,7 +1,9 @@
 import logging
 import codecs
 
-from user_sync.config.common import DictConfig, ConfigFileLoader
+from copy import deepcopy
+
+from user_sync.config.common import DictConfig, ConfigFileLoader, resolve_invocation_options
 from user_sync.error import AssertionException
 
 
@@ -34,11 +36,14 @@ class SignConfigLoader:
     def __init__(self, args: dict):
         self.logger = logging.getLogger('sign_config')
         self.args = args
-        self.invocation_options = self.load_invocation_options()
         self.main_config = self.load_main_config()
+        self.invocation_options = self.load_invocation_options()
     
     def load_invocation_options(self) -> dict:
-        return self.invocation_defaults
+        options = deepcopy(self.invocation_defaults)
+        invocation_config = self.main_config.get_dict_config('invocation_defaults', True)
+        options = resolve_invocation_options(options, invocation_config, self.invocation_defaults, self.args)
+        return options
 
     def load_main_config(self) -> DictConfig:
         config_filename = self.args.get('config_filename') or self.config_defaults['config_filename']

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -134,6 +134,18 @@ class SignConfigLoader(ConfigLoader):
         source_config_path = identity_config['connector']
         return self.config_loader.load_sub_config(source_config_path)
 
+    def get_target_options(self) -> (dict, dict):
+        target_configs = self.main_config.get_dict('sign_orgs')
+        if 'primary' not in target_configs:
+            raise AssertionException("'sign_orgs' config must specify a connector with 'primary' key")
+        primary_options = self.config_loader.load_sub_config(target_configs['primary'])
+        secondary_options = {}
+        for target_id, config_file in target_configs.items():
+            if target_id == 'primary':
+                continue
+            secondary_options[target_id] = self.config_loader.load_sub_config(config_file)
+        return primary_options, secondary_options
+
     def check_unused_config_keys(self):
         # not clear if we need this since we are validating the config schema
         pass

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -32,6 +32,7 @@ import user_sync.identity_type
 import user_sync.port
 from user_sync import flags
 from user_sync.engine import umapi as rules
+from user_sync.engine.common import AdobeGroup, PRIMARY_TARGET_NAME
 from user_sync.error import AssertionException
 import user_sync.post_sync.connectors as post_sync_connectors
 from .common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
@@ -244,7 +245,7 @@ class UMAPIConfigLoader(ConfigLoader):
                         'You must specify the groups to read when using the adobe-users "group" option')
                 options['adobe_group_filter'] = []
                 for group in adobe_users_spec[1].split(','):
-                    options['adobe_group_filter'].append(rules.AdobeGroup.create(group))
+                    options['adobe_group_filter'].append(AdobeGroup.create(group))
             else:
                 raise AssertionException('Unknown option "%s" for adobe-users' % adobe_users_action)
 
@@ -339,7 +340,7 @@ class UMAPIConfigLoader(ConfigLoader):
 
     def load_directory_groups(self):
         """
-        :rtype dict(str, list(user_sync.rules.AdobeGroup))
+        :rtype dict(str, list(AdobeGroup))
         """
         adobe_groups_by_directory_group = {}
         if self.main_config.get_dict_config('directory', True):
@@ -359,7 +360,7 @@ class UMAPIConfigLoader(ConfigLoader):
 
             adobe_groups = item.get_list('adobe_groups', True)
             for adobe_group in adobe_groups or []:
-                group = rules.AdobeGroup.create(adobe_group)
+                group = AdobeGroup.create(adobe_group)
                 if group is None:
                     validation_message = ('Bad adobe group: "%s" in directory group: "%s"' %
                                           (adobe_group, directory_group))
@@ -499,7 +500,7 @@ class UMAPIConfigLoader(ConfigLoader):
         additional_groups = directory_config.get_list('additional_groups', True) or []
         try:
             additional_groups = [{'source': re.compile(r['source']),
-                                  'target': rules.AdobeGroup.create(r['target'], index=False)}
+                                  'target': AdobeGroup.create(r['target'], index=False)}
                                  for r in additional_groups]
         except Exception as e:
             raise AssertionException("Additional group rule error: {}".format(str(e)))
@@ -538,8 +539,8 @@ class UMAPIConfigLoader(ConfigLoader):
         if exclude_group_names:
             exclude_groups = []
             for name in exclude_group_names:
-                group = rules.AdobeGroup.create(name)
-                if not group or group.get_umapi_name() != rules.PRIMARY_UMAPI_NAME:
+                group = AdobeGroup.create(name)
+                if not group or group.get_umapi_name() != PRIMARY_TARGET_NAME:
                     validation_message = 'Illegal value for %s in config file: %s' % ('exclude_groups', name)
                     if not group:
                         validation_message += ' (Not a legal group name)'
@@ -578,7 +579,7 @@ class UMAPIConfigLoader(ConfigLoader):
             # 1. it allows validation of group names, and matching them to adobe groups
             # 2. it allows removal of adobe groups not assigned by the hook
             for extended_adobe_group in extension_config.get_list('extended_adobe_groups', True) or []:
-                group = rules.AdobeGroup.create(extended_adobe_group)
+                group = AdobeGroup.create(extended_adobe_group)
                 if group is None:
                     message = 'Extension contains illegal extended_adobe_group spec: ' + str(extended_adobe_group)
                     raise AssertionException(message)
@@ -590,7 +591,7 @@ class UMAPIConfigLoader(ConfigLoader):
 
         # set the adobe group filter from the mapping, if requested.
         if options.get('adobe_group_mapped') is True:
-            options['adobe_group_filter'] = set(rules.AdobeGroup.iter_groups())
+            options['adobe_group_filter'] = set(AdobeGroup.iter_groups())
 
         return options
 

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -474,7 +474,7 @@ class UMAPIConfigLoader(ConfigLoader):
                         result[dict_key] = dict_val
         return result
 
-    def get_rule_options(self):
+    def get_engine_options(self):
         """
         Return a dict representing options for RuleProcessor.
         """

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -37,7 +37,7 @@ import user_sync.post_sync.connectors as post_sync_connectors
 from .common import DictConfig, ConfigFileLoader, resolve_invocation_options
 
 
-class ConfigLoader(object):
+class UMAPIConfigLoader:
     """
     Loads config files and does pathname expansion on settings that refer to files or directories
     """

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -34,10 +34,10 @@ from user_sync import flags
 from user_sync.engine import umapi as rules
 from user_sync.error import AssertionException
 import user_sync.post_sync.connectors as post_sync_connectors
-from .common import DictConfig, ConfigFileLoader, resolve_invocation_options
+from .common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
 
 
-class UMAPIConfigLoader:
+class UMAPIConfigLoader(ConfigLoader):
     """
     Loads config files and does pathname expansion on settings that refer to files or directories
     """

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -254,7 +254,7 @@ class UMAPIConfigLoader(ConfigLoader):
     def get_logging_config(self):
         return self.main_config.get_dict_config('logging', True)
 
-    def get_umapi_options(self):
+    def get_target_options(self):
         """
         Read and return the primary and secondary umapi connector configs.
         The primary is a singleton, the secondaries are a map from name to config.

--- a/user_sync/engine/common.py
+++ b/user_sync/engine/common.py
@@ -25,7 +25,10 @@ class AdobeGroup:
         return hash(frozenset(self.__dict__))
 
     def __str__(self):
-        return str(self.__dict__)
+        return 'AdobeGroup({})'.format(str(self.__dict__))
+
+    def __repr__(self):
+        return 'AdobeGroup({})'.format(str(self.__dict__))
 
     def get_qualified_name(self):
         prefix = ""

--- a/user_sync/engine/common.py
+++ b/user_sync/engine/common.py
@@ -1,0 +1,72 @@
+GROUP_NAME_DELIMITER = '::'
+PRIMARY_TARGET_NAME = None
+
+
+class AdobeGroup:
+    index_map = {}
+
+    def __init__(self, group_name, umapi_name, index=True):
+        """
+        :type group_name: str
+        :type umapi_name: str
+        """
+        self.group_name = group_name
+        self.umapi_name = umapi_name
+        if index:
+            AdobeGroup.index_map[(group_name, umapi_name)] = self
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset(self.__dict__))
+
+    def __str__(self):
+        return str(self.__dict__)
+
+    def get_qualified_name(self):
+        prefix = ""
+        if self.umapi_name is not None and self.umapi_name != PRIMARY_TARGET_NAME:
+            prefix = self.umapi_name + GROUP_NAME_DELIMITER
+        return prefix + self.group_name
+
+    def get_umapi_name(self):
+        return self.umapi_name
+
+    def get_group_name(self):
+        return self.group_name
+
+    @staticmethod
+    def _parse(qualified_name):
+        """
+        :type qualified_name: str
+        :rtype: str, str
+        """
+        parts = qualified_name.split(GROUP_NAME_DELIMITER)
+        group_name = parts.pop()
+        umapi_name = GROUP_NAME_DELIMITER.join(parts)
+        if len(umapi_name) == 0:
+            umapi_name = PRIMARY_TARGET_NAME
+        return group_name, umapi_name
+
+    @classmethod
+    def lookup(cls, qualified_name):
+        return cls.index_map.get(cls._parse(qualified_name))
+
+    @classmethod
+    def create(cls, qualified_name, index=True):
+        group_name, umapi_name = cls._parse(qualified_name)
+        existing = cls.index_map.get((group_name, umapi_name))
+        if existing:
+            return existing
+        elif len(group_name) > 0:
+            return cls(group_name, umapi_name, index)
+        else:
+            return None
+
+    @classmethod
+    def iter_groups(cls):
+        return cls.index_map.items()


### PR DESCRIPTION
Summary of changes
* Rename ConfigLoader to UMAPIConfigLoader
* Define abstract base class ConfigLoader with config loader interface
* Refactor invocation option resolution
* Add schema validation to Sign config
* Implement generic ConfigLoader interface in Sign config loader
* Move certain engine components to a "common" engine module
* Bunch of new Sign config loader tests