### PR TITLE
refactor and addition of begin_work_sign 

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -49,6 +49,7 @@ import user_sync.post_sync.connectors.sign_sync
 import user_sync.resource
 import user_sync.engine.umapi
 import user_sync.config.user_sync
+import user_sync.config.sign_sync
 import user_sync.connector.connector_umapi
 from user_sync.error import AssertionException
 from user_sync.post_sync.manager import PostSyncManager
@@ -170,7 +171,6 @@ def main():
               help='user attributes on the Adobe side are updated from the directory.')
 def sync(**kwargs):
     """Run User Sync [default command]"""
-
     sign_config_file = kwargs.get('sign_sync_config')
     if 'sign_sync_config' in kwargs:
         del(kwargs['sign_sync_config'])
@@ -192,7 +192,6 @@ def sync(**kwargs):
               cls=user_sync.cli.OptionMulti,
               type=list,
               metavar='all|mapped|group [group list or path-to-file.csv]') #default should mapped
-# Correct Sign only user actions??
 @click.option('--sign-only-user-action',
               help="specify what action to take on Sign users that don't match users from the "
                    "directory.  Options are 'exclude' (from all changes), "
@@ -203,7 +202,7 @@ def sync(**kwargs):
 def sign_sync(**kwargs):
     """Run Sign Sync """
     #load the config files (sign-sync-config.yml) and start the file logger
-    run_sync(config.SignConfigLoader(kwargs), begin_work_sign)
+    run_sync(sign_sync.SignConfigLoader(kwargs), begin_work_sign)
 
 
 def run_sync(config_loader, begin_work):

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -420,7 +420,6 @@ def begin_work_umapi(config_loader):
     """
     :type config_loader: config.UMAPIConfigLoader
     """
-    # directory_groups = config_loader.get_directory_groups()
     rule_config = config_loader.get_rule_options()
     directory_connector, directory_groups = load_root_config(config_loader, rule_config['new_account_type'])
     # make sure that all the adobe groups are from known umapi connector names
@@ -478,7 +477,7 @@ def begin_work_umapi(config_loader):
 
 
 def begin_work_sign(sign_config_loader):
-    rule_config = SignConfigLoader.get_engine_options()
+    rule_config = sign_config_loader.get_engine_options()
     directory_connector, directory_groups = load_root_config(sign_config_loader, rule_config['new_account_type'])
     sign_engine = user_sync.engine.sign.SignSyncEngine(rule_config)
     sign_engine.run(directory_groups, directory_connector)


### PR DESCRIPTION
-Extracted run_sync from sync() for shared functionality of sync() and sign_sync().  
-sync() and sign_sync() were refactored, leaving sync() to function as it did before. 
-Extracted load_root_directory from begin_work() for shared functionality between begin_work_sign() and begin_work_umapi(). Finished functionality of begin_work_sign(). 