### PR TITLE
Common engine methods

### DIFF
--- a/tests/test_sign_engine.py
+++ b/tests/test_sign_engine.py
@@ -23,10 +23,16 @@ def test_load_users_and_groups(example_engine, example_user):
     def dir_user_replacement(groups, extended_attributes, all_users):
         return six.itervalues(user)
 
-    # replace the call to load directory groups and users with the example user dict. this dict will then be modified
-    # by other methods in the engine/sign.py which are almost identical to the same methods in engine/umapi.py right now
-    # these methods should be altered for sign-specific usage - for example, there's no need to specify an identity
-    # type for sign-syncing purposes, but it has been left in there so that the code can run
     dc.load_users_and_groups = dir_user_replacement
     example_engine.read_desired_user_groups({'directory_group': 'adobe_group'}, dc)
-    assert example_engine.directory_user_by_user_key != {}
+    # if the user has an email attribute, the method will index the user dict by email, which is how it's passed
+    # in in this test anyway
+    assert example_engine.directory_user_by_user_key == user
+
+
+def test_get_directory_user_key(example_engine, example_user):
+    # user = {'user@example.com': example_user}
+    # if the method is passed a dict with an email, it should return the email key
+    assert example_engine.get_directory_user_key(example_user) == example_user['email']
+    # if the user object passed in has no email value, it should return None
+    assert example_engine.get_directory_user_key({'': {'username': 'user@example.com'}}) is None

--- a/tests/test_sign_engine.py
+++ b/tests/test_sign_engine.py
@@ -28,5 +28,5 @@ def test_load_users_and_groups(example_engine, example_user):
     # these methods should be altered for sign-specific usage - for example, there's no need to specify an identity
     # type for sign-syncing purposes, but it has been left in there so that the code can run
     dc.load_users_and_groups = dir_user_replacement
-    directory_users = example_engine.read_desired_user_groups({'directory_group': 'adobe_group'}, dc)
-    assert directory_users is not None
+    example_engine.read_desired_user_groups({'directory_group': 'adobe_group'}, dc)
+    assert example_engine.directory_user_by_user_key != {}

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -65,15 +65,16 @@ class SignSyncEngine:
         if self.test_mode:
             self.logger.info("Sign Sync disabled in test mode")
             return
-        directory_users = self.read_desired_user_groups(directory_groups, directory_connector)
-        if directory_users is None:
-            raise AssertionException("Error retrieving users from directory")
+        # directory_users = self.read_desired_user_groups(directory_groups, directory_connector)
+        self.read_desired_user_groups(directory_groups, directory_connector)
+        # if directory_users is None:
+        #     raise AssertionException("Error retrieving users from directory")
         for org_name, sign_connector in self.connectors.items():
             # create any new Sign groups
             for new_group in set(self.user_groups[org_name]) - set(sign_connector.sign_groups()):
                 self.logger.info("Creating new Sign group: {}".format(new_group))
                 sign_connector.create_group(new_group)
-            self.update_sign_users(directory_users, sign_connector, org_name)
+            self.update_sign_users(self.directory_user_by_user_key, sign_connector, org_name)
 
     def update_sign_users(self, directory_users, sign_connector, org_name):
         sign_users = sign_connector.get_users()
@@ -206,7 +207,7 @@ class SignSyncEngine:
             # if not self.is_selected_user_key(user_key):
             #     continue
 
-        return directory_user_by_user_key
+        # return directory_user_by_user_key
 
     def get_directory_user_key(self, directory_user):
         """
@@ -251,3 +252,4 @@ class SignSyncEngine:
             self.logger.warning('Found user with no identity type, using %s: %s', identity_type, directory_user)
         return identity_type
 
+ 

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -18,7 +18,6 @@ class SignSyncEngine:
         'directory_group_filter': None,
         'entitlement_groups': [],
         'identity_types': [],
-        'new_account_type': identity_type.FEDERATED_IDENTITY_TYPE,
         'sign_only_limit': 200,
         'sign_orgs': [],
         'test_mode': False,
@@ -176,8 +175,6 @@ class SignSyncEngine:
         return mapped_admin_roles
 
     def read_desired_user_groups(self, mappings, directory_connector):
-        # this is only the first part of the same method in engine/umapi
-        # going to make it return the modified directory users list
         self.logger.debug('Building work list...')
 
         options = self.options
@@ -202,54 +199,11 @@ class SignSyncEngine:
                 continue
             directory_user_by_user_key[user_key] = directory_user
 
-            # if not self.is_directory_user_in_groups(directory_user, directory_group_filter):
-            #     continue
-            # if not self.is_selected_user_key(user_key):
-            #     continue
-
-        # return directory_user_by_user_key
-
     def get_directory_user_key(self, directory_user):
         """
-        Identity-type aware user key management for directory users
         :type directory_user: dict
         """
-        id_type = self.get_identity_type_from_directory_user(directory_user)
-        return self.get_user_key(id_type, directory_user['username'], directory_user['domain'], directory_user['email'])
-
-    def get_user_key(self, id_type, username, domain, email=None):
-        """
-        Construct the user key for a directory or adobe user.
-        The user key is the stringification of the tuple (id_type, username, domain)
-        but the domain part is left empty if the username is an email address.
-        If the parameters are invalid, None is returned.
-        :param username: (required) username of the user, can be his email
-        :param domain: (optional) domain of the user
-        :param email: (optional) email of the user
-        :param id_type: (required) id_type of the user
-        :return: string "id_type,username,domain" (or None)
-        :rtype: str
-        """
-        id_type = identity_type.parse_identity_type(id_type)
-        email = normalize_string(email) if email else None
-        username = normalize_string(username) or email
-        domain = normalize_string(domain)
-
-        if not id_type:
-            return None
-        if not username:
-            return None
-        if username.find('@') >= 0:
-            domain = ""
-        elif not domain:
-            return None
-        return six.text_type(id_type) + u',' + six.text_type(username) + u',' + six.text_type(domain)
-
-    def get_identity_type_from_directory_user(self, directory_user):
-        identity_type = directory_user.get('identity_type')
-        if identity_type is None:
-            identity_type = self.options['new_account_type']
-            self.logger.warning('Found user with no identity type, using %s: %s', identity_type, directory_user)
-        return identity_type
-
- 
+        email = directory_user.get('email')
+        if email:
+            return six.text_type(email)
+        return None


### PR DESCRIPTION
I removed the methods copied from engine/umapi that modified the directory_users dict in ways that are irrelevant to Sign (namely username, domain, and identity type). I updated the test. I also removed the default option for identity type since Sign does not use id types.