### PR TITLE
get credential in sign connector init

### DIFF
--- a/examples/sign/connector-sign.yml
+++ b/examples/sign/connector-sign.yml
@@ -1,3 +1,12 @@
 host: api.echosign.com
 key: [Sign API Key]
 admin_email: user@example.com
+# (optional) You can store credentials in the operating system credential store
+# (Windows Credential Manager, Mac Keychain, Linux Freedesktop Secret Service
+# or KWallet - these will be built into the Linux distribution).
+# To use this feature, uncomment the following entry and remove the
+# key entry above.
+# The actual credential value are placed in the credential store with the
+# username as the admin_email field value, and the key name (perhaps called internet
+# or network address) as the value below.
+#secure_key_key: sign_key

--- a/user_sync/connector/connector_sign.py
+++ b/user_sync/connector/connector_sign.py
@@ -35,16 +35,16 @@ class SignConnector(object):
         caller_config = user_sync.config.common.DictConfig('sign_configuration', caller_options)
         sign_builder = user_sync.config.common.OptionsBuilder(caller_config)
         sign_builder.require_string_value('host')
-        sign_builder.require_string_value('key')
         sign_builder.require_string_value('admin_email')
         sign_builder.set_string_value('console_org', None)
         options = sign_builder.get_options()
+        key = caller_config.get_credential('key', options['admin_email'])
         self.console_org = options['console_org']
         self.name = 'sign_{}'.format(self.console_org)
         self.logger = logging.getLogger(self.name)
         caller_config.report_unused_values(self.logger)
         self.sign_client = SignClient(host=options['host'],
-                                      key=options['key'],
+                                      key=key,
                                       admin_email=options['admin_email'],
                                       logger=self.logger)
 


### PR DESCRIPTION
I added the get_credential method into the init function for Sign Connector and passed the outcome of this into the parameters for the Sign Client. Added comments in connector-sign.yml to help users use the secure storage functionality.