### PR TITLE
Additions and modifications to Sign Sync Summary - matched groups, updated groups, updated admin roles

### DIFF
--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -48,24 +48,14 @@ class SignSyncEngine:
         sign_orgs = sync_config.get_list('sign_orgs')
         self.connectors = {cfg.get('console_org'): SignConnector(cfg) for cfg in sign_orgs}
         # self.create_new_users = sync_config.get_bool("create_new_users")
-        self.total_sign_user_count = 0
-        self.sign_users_created_count = 0
-        self.sign_users_removed_count = 0
-        self.sign_users_updated_count = 0
-        self.sign_users_with_mapped_groups = set()
+        self.total_sign_user_count = set()
+        self.sign_users_created_count = set()
+        self.sign_users_removed_count = set()
+        self.sign_users_updated_count = set()
+        self.sign_users_with_matched_groups = set()
         self.sign_users_assigned_to_groups = set()
         self.sign_users_assigned_to_admin_role = set()
-        self.action_summary = {
-            'directory_users_read': 0,
-            'sign_admins_mapped': 0,
-            'sign_users_created': 0,
-            'sign_users_read': 0,
-            'sign_users_removed': 0,
-            'sign_users_updated': 0,
-            'sign_users_with_mapped_groups': 0,
-            'sign_users_assigned_to_groups': 0,
-            'sign_users_assigned_admin_role': 0
-        }
+        self.action_summary = {}
 
     def run(self, directory_groups, directory_connector):
         """
@@ -99,14 +89,14 @@ class SignSyncEngine:
         # Number of directory users read
         self.action_summary['directory_users_read'] = len(self.directory_user_by_user_key)
         # Number of Sign Admins mapped
-        self.action_summary['sign_admins_mapped'] = len(self.admin_roles)
+        self.action_summary['sign_admins_matched'] = len(self.admin_roles)
         # Total Number of Sign users
-        self.action_summary['sign_users_read'] = self.total_sign_user_count
+        self.action_summary['sign_users_read'] = len(self.total_sign_user_count)
         # Number of Sign users created/removed/updated
-        self.action_summary['sign_users_created'] = self.sign_users_created_count
-        self.action_summary['sign_users_removed'] = self.sign_users_removed_count
-        self.action_summary['sign_users_updated'] = self.sign_users_updated_count
-        self.action_summary['sign_users_with_mapped_groups'] = len(self.sign_users_with_mapped_groups)
+        self.action_summary['sign_users_created'] = len(self.sign_users_created_count)
+        self.action_summary['sign_users_removed'] = len(self.sign_users_removed_count)
+        self.action_summary['sign_users_updated'] = len(self.sign_users_updated_count)
+        self.action_summary['sign_users_with_matched_groups'] = len(self.sign_users_with_matched_groups)
         self.action_summary['sign_users_assigned_to_groups'] = len(self.sign_users_assigned_to_groups)
         self.action_summary['sign_users_assigned_admin_role'] = len(self.sign_users_assigned_to_admin_role)
 
@@ -116,10 +106,10 @@ class SignSyncEngine:
             ['sign_users_created', 'Number of Sign users created'],
             ['sign_users_removed', 'Number of Sign users removed'],
             ['sign_users_updated', 'Number of Sign users updated'],
-            ['sign_admins_mapped', 'Number of Sign admins mapped'],
-            ['sign_users_with_mapped_groups', 'Number of Sign users with mapped groups'],
-            ['sign_users_assigned_to_groups', 'Number of Sign users assigned to a group'],  # maybe change wording here?
-            ['sign_users_assigned_admin_role', 'Number of Sign users assigned an admin role']
+            ['sign_admins_matched', 'Number of Sign admins matched'],
+            ['sign_users_with_matched_groups', 'Number of Sign users with matched groups'],
+            ['sign_users_assigned_to_groups', 'Number of Sign users with groups updated'],
+            ['sign_users_assigned_admin_role', 'Number of Sign users admin roles updated']
         ]
 
         pad = 0
@@ -147,7 +137,7 @@ class SignSyncEngine:
             for group in self.user_groups[org_name]:
                 if group in directory_user['groups']:
                     assignment_group = group
-                    self.sign_users_with_mapped_groups.add(directory_user)
+                    self.sign_users_with_matched_groups.add(directory_user)
                     break
 
             if assignment_group is None:
@@ -207,7 +197,6 @@ class SignSyncEngine:
         admin_roles = sync_config.get_list('admin_roles', True)
         if admin_roles is None:
             return {}
-        # make this a class level variable so that we can grab the len for the action summary?
         mapped_admin_roles = {}
         for mapping in admin_roles:
             sign_role = mapping.get('sign_role')
@@ -303,14 +292,16 @@ class SignSyncEngine:
                 "lastName": sign_user['lastName'],
                 "roles": user_roles,
             }
-            if sign_user['group'].lower() == assignment_group and self.roles_match(user_roles, sign_user['roles']):
+            groups_match = sign_user['group'].lower() == assignment_group
+            roles_match = self.roles_match(user_roles, sign_user['roles'])
+            if groups_match and roles_match:
                 self.logger.debug("skipping Sign update for '{}' -- no updates needed".format(directory_user['email']))
                 return
-            try:
-                # no need to check if the groups/role assignment is to default/NORMAL since we want to include that anyway
-                # which i guess means these numbers will always be the same?
+            if not groups_match:
                 self.sign_users_assigned_to_groups.add(sign_user)
+            if not roles_match:
                 self.sign_users_assigned_to_admin_role.add(sign_user)
+            try:
                 sign_connector.update_user(sign_user['userId'], update_data)
                 self.logger.info("Updated Sign user '{}', Group: '{}', Roles: {}".format(
                     directory_user['email'], assignment_group, update_data['roles']))
@@ -339,8 +330,6 @@ class SignSyncEngine:
             self.logger.info("Inserted Sign user '{}', Group: '{}', Roles: {}".format(
                 directory_user['email'], assignment_group, insert_data['roles']))
             self.sign_users_created += 1
-            self.sign_users_assigned_to_groups.add(directory_user)
-            self.sign_users_assigned_to_admin_role.add(directory_user)
         except AssertionException as e:
             self.logger.error(format(e))
         return

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -339,6 +339,8 @@ class SignSyncEngine:
             self.logger.info("Inserted Sign user '{}', Group: '{}', Roles: {}".format(
                 directory_user['email'], assignment_group, insert_data['roles']))
             self.sign_users_created += 1
+            self.sign_users_assigned_to_groups.add(directory_user)
+            self.sign_users_assigned_to_admin_role.add(directory_user)
         except AssertionException as e:
             self.logger.error(format(e))
         return

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -45,12 +45,6 @@ class SignSyncEngine:
         self.directory_user_by_user_key = {}
         # dict w/ structure - umapi_name -> adobe_group -> [set of roles]
         self.admin_roles = self._admin_role_mapping(sync_config)
-
-        # builder = user_sync.config.common.OptionsBuilder(sync_config)
-        # builder.set_string_value('logger_name', self.name)
-        # builder.set_bool_value('test_mode', False)
-        # options = builder.get_options()
-
         sign_orgs = sync_config.get_list('sign_orgs')
         self.connectors = {cfg.get('console_org'): SignConnector(cfg) for cfg in sign_orgs}
         # self.create_new_users = sync_config.get_bool("create_new_users")
@@ -58,6 +52,9 @@ class SignSyncEngine:
         self.sign_users_created_count = 0
         self.sign_users_removed_count = 0
         self.sign_users_updated_count = 0
+        self.sign_users_with_mapped_groups = set()
+        self.sign_users_assigned_to_groups = set()
+        self.sign_users_assigned_to_admin_role = set()
         self.action_summary = {
             'directory_users_read': 0,
             'sign_admins_mapped': 0,
@@ -65,7 +62,9 @@ class SignSyncEngine:
             'sign_users_read': 0,
             'sign_users_removed': 0,
             'sign_users_updated': 0,
-
+            'sign_users_with_mapped_groups': 0,
+            'sign_users_assigned_to_groups': 0,
+            'sign_users_assigned_admin_role': 0
         }
 
     def run(self, directory_groups, directory_connector):
@@ -107,6 +106,9 @@ class SignSyncEngine:
         self.action_summary['sign_users_created'] = self.sign_users_created_count
         self.action_summary['sign_users_removed'] = self.sign_users_removed_count
         self.action_summary['sign_users_updated'] = self.sign_users_updated_count
+        self.action_summary['sign_users_with_mapped_groups'] = len(self.sign_users_with_mapped_groups)
+        self.action_summary['sign_users_assigned_to_groups'] = len(self.sign_users_assigned_to_groups)
+        self.action_summary['sign_users_assigned_admin_role'] = len(self.sign_users_assigned_to_admin_role)
 
         action_summary_description = [
             ['directory_users_read', 'Number of directory users read'],
@@ -115,6 +117,9 @@ class SignSyncEngine:
             ['sign_users_removed', 'Number of Sign users removed'],
             ['sign_users_updated', 'Number of Sign users updated'],
             ['sign_admins_mapped', 'Number of Sign admins mapped'],
+            ['sign_users_with_mapped_groups', 'Number of Sign users with mapped groups'],
+            ['sign_users_assigned_to_groups', 'Number of Sign users assigned to a group'],  # maybe change wording here?
+            ['sign_users_assigned_admin_role', 'Number of Sign users assigned an admin role']
         ]
 
         pad = 0
@@ -142,6 +147,7 @@ class SignSyncEngine:
             for group in self.user_groups[org_name]:
                 if group in directory_user['groups']:
                     assignment_group = group
+                    self.sign_users_with_mapped_groups.add(directory_user)
                     break
 
             if assignment_group is None:
@@ -201,7 +207,7 @@ class SignSyncEngine:
         admin_roles = sync_config.get_list('admin_roles', True)
         if admin_roles is None:
             return {}
-
+        # make this a class level variable so that we can grab the len for the action summary?
         mapped_admin_roles = {}
         for mapping in admin_roles:
             sign_role = mapping.get('sign_role')
@@ -290,23 +296,26 @@ class SignSyncEngine:
         return identity_type
 
     def update_existing_users(self, sign_connector, sign_user, directory_user, group_id, user_roles, assignment_group):
-        update_data = {
-            "email": sign_user['email'],
-            "firstName": sign_user['firstName'],
-            "groupId": group_id,
-            "lastName": sign_user['lastName'],
-            "roles": user_roles,
-        }
-        if sign_user['group'].lower() == assignment_group and self.roles_match(user_roles, sign_user['roles']):
-            self.logger.debug("skipping Sign update for '{}' -- no updates needed".format(directory_user['email']))
-            return
-        try:
-            sign_connector.update_user(sign_user['userId'], update_data)
-            self.logger.info("Updated Sign user '{}', Group: '{}', Roles: {}".format(
-                directory_user['email'], assignment_group, update_data['roles']))
-            self.sign_users_updated_count += 1
-        except AssertionError as e:
-            self.logger.error("Error updating user {}".format(e))
+            update_data = {
+                "email": sign_user['email'],
+                "firstName": sign_user['firstName'],
+                "groupId": group_id,
+                "lastName": sign_user['lastName'],
+                "roles": user_roles,
+            }
+            if sign_user['group'].lower() == assignment_group and self.roles_match(user_roles, sign_user['roles']):
+                self.logger.debug("skipping Sign update for '{}' -- no updates needed".format(directory_user['email']))
+                return
+            try:
+                # no need to check if the groups/role assignment is to default/NORMAL since we want to include that anyway
+                # which i guess means these numbers will always be the same?
+                self.sign_users_assigned_to_groups.add(sign_user)
+                self.sign_users_assigned_to_admin_role.add(sign_user)
+                sign_connector.update_user(sign_user['userId'], update_data)
+                self.logger.info("Updated Sign user '{}', Group: '{}', Roles: {}".format(
+                    directory_user['email'], assignment_group, update_data['roles']))
+            except AssertionError as e:
+                self.logger.error("Error updating user {}".format(e))
 
     def insert_new_users(self, sign_connector, directory_user, user_roles, group_id, assignment_group):
         """


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
I added variables to track the number of users with groups matching the mapping rules for the Sign Sync. I also added variables to count the number of users with group membership updates and admin role updates. All of these new variables are tracked with logic in the appropriate places in the code. 

## Testing Steps
No testing was done for this PR - it is just affecting logging.

<!-- Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->

Fixes #144 
