### PR TITLE
remove unused methods from read_desired_user_groups in Sign Engine

### DIFF
--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -70,7 +70,6 @@ class SignSyncEngine:
         self.sign_users_assigned_to_admin_role = set()
         self.action_summary = {}
 
-
     def run(self, directory_groups, directory_connector):
         """
         Run the Sign sync
@@ -288,41 +287,6 @@ class SignSyncEngine:
             return six.text_type(email)
         return None
 
-    def get_user_key(self, id_type, username, domain, email=None):
-        """
-        Construct the user key for a directory or adobe user.
-        The user key is the stringification of the tuple (id_type, username, domain)
-        but the domain part is left empty if the username is an email address.
-        If the parameters are invalid, None is returned.
-        :param username: (required) username of the user, can be his email
-        :param domain: (optional) domain of the user
-        :param email: (optional) email of the user
-        :param id_type: (required) id_type of the user
-        :return: string "id_type,username,domain" (or None)
-        :rtype: str
-        """
-        id_type = identity_type.parse_identity_type(id_type)
-        email = normalize_string(email) if email else None
-        username = normalize_string(username) or email
-        domain = normalize_string(domain)
-
-        if not id_type:
-            return None
-        if not username:
-            return None
-        if username.find('@') >= 0:
-            domain = ""
-        elif not domain:
-            return None
-        return six.text_type(id_type) + u',' + six.text_type(username) + u',' + six.text_type(domain)
-
-    def get_identity_type_from_directory_user(self, directory_user):
-        identity_type = directory_user.get('identity_type')
-        if identity_type is None:
-            identity_type = self.options['new_account_type']
-            self.logger.warning('Found user with no identity type, using %s: %s', identity_type, directory_user)
-        return identity_type
-
     def extract_mapped_group(self, directory_user_group, group_mapping):
         for directory_group, sign_group_mapping in group_mapping.items():
             if (directory_user_group[0] == directory_group):
@@ -401,4 +365,4 @@ class SignSyncEngine:
                 except AssertionException as e:
                     self.logger.error("Error deactivating user {}, {}".format(sign_user['email'], e))
                 return
-                
+            


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
I removed two methods that were previously copied from the UMAPI engine method for reading directory groups.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
No testing completed since these methods were not called anywhere.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #xxx
