### PR TITLE
test_mode for Sign sync

### DIFF
--- a/examples/sign/sign-sync-config.yml
+++ b/examples/sign/sign-sync-config.yml
@@ -54,4 +54,7 @@ logging:
 # Defaults for options that can be passed as CLI options
 invocation_defaults:
   users: mapped
-
+# test_mode presents post_sync output without performing any updates of users or user groups to the Sign Dashboard
+# test_mode possible values are yes or no. (default no)
+# test_mode is independent of user_sync test mode.
+  test_mode: False

--- a/sign_client/client.py
+++ b/sign_client/client.py
@@ -7,13 +7,12 @@ class SignClient:
     version = 'v5'
     _endpoint_template = 'api/rest/{}/'
 
-    def __init__(self, host, integration_key, admin_email, logger=None, test_mode=False):
+    def __init__(self, host, integration_key, admin_email, logger=None):
         self.host = host
         self.integration_key = integration_key
         self.admin_email = admin_email
         self.api_url = None
         self.groups = None
-        self.test_mode = test_mode
         self.logger = logger or logging.getLogger("sign_client_{}".format(self.integration_key[0:4]))
 
     def _init(self):
@@ -137,11 +136,11 @@ class SignClient:
         """
         if self.api_url is None or self.groups is None:
             self._init()
-        if not self.test_mode:
-            res = requests.post(self.api_url + 'groups', headers=self.header_json(), data=json.dumps({'groupName': group}))
-            if res.status_code != 201:
-                raise AssertionException("Failed to create Sign group '{}' (reason: {})".format(group, res.reason))
-            self.groups[group] = res.json()['groupId']
+
+        res = requests.post(self.api_url + 'groups', headers=self.header_json(), data=json.dumps({'groupName': group}))
+        if res.status_code != 201:
+            raise AssertionException("Failed to create Sign group '{}' (reason: {})".format(group, res.reason))
+        self.groups[group] = res.json()['groupId']
 
     def update_user(self, user_id, data):
         """
@@ -152,9 +151,6 @@ class SignClient:
         """
         if self.api_url is None or self.groups is None:
             self._init()
-
-        if self.test_mode:
-            return
 
         res = requests.put(self.api_url + 'users/' + user_id, headers=self.header_json(), data=json.dumps(data))
         if res.status_code != 200:

--- a/tests/fixture/sign-sync-config.yml
+++ b/tests/fixture/sign-sync-config.yml
@@ -50,3 +50,4 @@ logging:
 # Defaults for options that can be passed as CLI options
 invocation_defaults:
   users: mapped
+  test_mode: False

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -157,7 +157,7 @@ def test_engine_options(sign_config_file, modify_sign_config, tmp_sign_connector
 
 
 def test_load_invocation_options(sign_config_file, modify_sign_config, tmp_sign_connector_config, tmp_config_files):
-    sign_config_file = modify_sign_config(['invocation_defaults'], {'users': 'mapped'})
+    sign_config_file = modify_sign_config(['invocation_defaults'], {'users': 'mapped', 'test_mode': False})
     args = {'config_filename': sign_config_file}
     config = SignConfigLoader(args)
     options = config.load_invocation_options()

--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -196,6 +196,8 @@ def sync(**kwargs):
               cls=user_sync.cli.OptionMulti,
               type=list,
               metavar='exclude|preserve|delete')
+@click.option('-t/-T', '--test-mode/--no-test-mode', default=None,
+              help='enable test mode (API calls do not execute changes).')
 def sign_sync(**kwargs):
     """Run Sign Sync """
     # load the config files (sign-sync-config.yml) and start the file logger

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -42,6 +42,7 @@ def config_schema() -> Schema:
         },
         'invocation_defaults': {
             'users': Or('mapped', 'all'), #TODO: single "source of truth" for these options
+            'test_mode':  bool,
             #'directory_group_filter': Or('mapped', 'all', None)
         }
     })
@@ -67,7 +68,8 @@ class SignConfigLoader(ConfigLoader):
     }
 
     invocation_defaults = {
-        'users': ['mapped']
+        'users': ['mapped'],
+        'test_mode': False
     }
 
     DEFAULT_ORG_NAME = 'primary'
@@ -172,6 +174,7 @@ class SignConfigLoader(ConfigLoader):
         options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
         invocation_defaults = self.main_config.get_dict_config('invocation_defaults')
         options['users'] = invocation_defaults.get_string('users')
+        options['test_mode'] = invocation_defaults.get_bool('test_mode')
         return options
 
     def check_unused_config_keys(self):

--- a/user_sync/connector/connector_sign.py
+++ b/user_sync/connector/connector_sign.py
@@ -35,7 +35,7 @@ class SignConnector(object):
         self.console_org = org_name
         self.name = 'sign_{}'.format(self.console_org)
         self.logger = logging.getLogger(self.name)
-
+        self.test_mode = test_mode
         caller_config = user_sync.config.common.DictConfig('sign_configuration', caller_options)
         sign_builder = user_sync.config.common.OptionsBuilder(caller_config)
         sign_builder.require_string_value('host')
@@ -50,26 +50,29 @@ class SignConnector(object):
         self.sign_client = SignClient(host=options['host'],
                                       integration_key=integration_key,
                                       admin_email=options['admin_email'],
-                                      logger=self.logger,
-                                      test_mode=test_mode)
+                                      logger=self.logger)
 
     def sign_groups(self):
         return self.sign_client.get_groups()
 
     def create_group(self, new_group):
-        return self.sign_client.create_group(new_group)
+        if not self.test_mode:
+            self.sign_client.create_group(new_group)
 
     def get_users(self):
         return self.sign_client.get_users()
 
     def update_user(self, user_id, update_data):
-        return self.sign_client.update_user(user_id, update_data)
+        if not self.test_mode:
+            self.sign_client.update_user(user_id, update_data)
 
     def get_group(self, assignment_group):
         return self.sign_client.groups.get(assignment_group)
 
     def insert_user(self, insert_data):
-        return self.sign_client.insert_user(insert_data)
+        if not self.test_mode:
+            self.sign_client.insert_user(insert_data)
 
     def deactivate_user(self, user_id):
-        return self.sign_client.deactivate_user(user_id)
+        if not self.test_mode:
+            self.sign_client.deactivate_user(user_id)

--- a/user_sync/connector/connector_sign.py
+++ b/user_sync/connector/connector_sign.py
@@ -30,7 +30,7 @@ class SignConnector(object):
 
     neptune_console = False
 
-    def __init__(self, caller_options, org_name):
+    def __init__(self, caller_options, org_name, test_mode):
         """
         :type caller_options: dict
         """
@@ -49,7 +49,8 @@ class SignConnector(object):
         self.sign_client = SignClient(host=options['host'],
                                       key=key,
                                       admin_email=options['admin_email'],
-                                      logger=self.logger)
+                                      logger=self.logger,
+                                      test_mode=test_mode)
 
     def sign_groups(self):
         return self.sign_client.get_groups()


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Test mode for sign_sync will show expected result of sign_sync, but API calls will not execute changes. This option can be changed in the sign-sync-config and as a CLI option. 


## Testing Steps
* Manual testing was done against Sign(GPS and Neptune) to ensure no changes were made when sign_sync test mode was run. 


Fixes #153 
