### PR TITLE
Improve get_directory_group

### DIFF
--- a/examples/sign/sign-sync-config.yml
+++ b/examples/sign/sign-sync-config.yml
@@ -25,23 +25,26 @@ user_management:
   # Example 1 - group assignment
   - directory_group: Sign Users 1
     sign_group: Group 1
-    admin_role:
+    group_admin: False
+    account_admin: False
+
   # Example 2 - group admin assignment
   - directory_group: Sign Group Admins 1
     sign_group: primary::Group 2
-    admin_role: 
-      - GROUP_ADMIN
+    group_admin: True
+    account_admin: False
+
   # Example 3 - account admin assignment
   # - directory_group: Sign Admins
   #   sign_group: secondary::Group 3
-  #   admin_role: 
-  #     - ACCOUNT_ADMIN
+  #   group_admin: False
+  #   account_admin: True
+
   # Example 4 - create user if `create_users` is `True`, otherwise do nothing
   # - directory_group: Sign Normal Users
   #   sign_group: tertiary::Group 4
-  #   admin_role:
-  #     - ACCOUNT_ADMIN
-  #     - GROUP_ADMIN
+  #   group_admin: True
+  #   account_admin: True
   
 # Logging options
 logging:

--- a/tests/fixture/sign-sync-config.yml
+++ b/tests/fixture/sign-sync-config.yml
@@ -25,12 +25,14 @@ user_management:
   # Example 1 - group assignment
   - directory_group: Sign Users 1
     sign_group: Group 1
-    admin_role:
+    group_admin:
+    account_admin:
   # Example 2 - group admin assignment
   - directory_group: Sign Group Admins 1
     sign_group: primary::Group 2
-    admin_role: 
-      - GROUP_ADMIN
+    group_admin: True
+    account_admin: False
+
   # Example 3 - account admin assignment
   # - directory_group: Sign Admins
   #   sign_group: secondary::Group 3

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -45,31 +45,6 @@ def test_invocation_defaults(modify_sign_config, tmp_sign_connector_config, tmp_
 # NOTE: tmp_sign_connector_config and tmp_config_files are needed to prevent the ConfigFileLoader
 # from complaining that there are no temporary sign connector or ldap connector files
 def test_group_config(modify_sign_config, tmp_sign_connector_config, tmp_config_files):
-    """ensure that group mappings are loaded correctly"""
-    # simple case
-    group_config = [{'directory_group': 'Test Group 1', 'sign_group': 'Sign Group 1'}]
-    sign_config_file = modify_sign_config(['user_management'], group_config)
-    args = {'config_filename': sign_config_file}
-    config = SignConfigLoader(args)
-    group_mappings = config.get_directory_groups()
-    assert 'Test Group 1' in group_mappings
-    assert group_mappings['Test Group 1']['groups'] == [AdobeGroup.create('Sign Group 1')]
-
-    # complex case
-    group_config.append({'directory_group': 'Test Group 2', 'sign_group': 'Sign Group 2', 'group_admin': False, 'account_admin': False})
-    group_config.append({'directory_group': 'Test Group 2', 'sign_group': 'Sign Group 3', 'group_admin': True, 'account_admin': None})
-    sign_config_file = modify_sign_config(['user_management'], group_config)
-    args = {'config_filename': sign_config_file}
-    config = SignConfigLoader(args)
-    group_mappings = config.get_directory_groups()
-    assert len(group_mappings) == 2
-    assert 'Test Group 1' in group_mappings
-    assert 'Test Group 2' in group_mappings
-    for mapping in group_mappings['Test Group 2']['groups']:
-        assert mapping in [AdobeGroup.create('Sign Group 2'), AdobeGroup.create('Sign Group 3')]
-
-
-def test_group_config_complex(modify_sign_config, tmp_sign_connector_config, tmp_config_files):
 
     def load_sign_groups(group_config):
         sign_config_file = modify_sign_config(['user_management'], group_config)
@@ -82,9 +57,8 @@ def test_group_config_complex(modify_sign_config, tmp_sign_connector_config, tmp
         assert mappings[name]['priority'] == priority
         for r in roles:
             assert r in mappings[name]['roles']
-        names = [ag.group_name for ag in mappings[name]['groups']]
         for g in sign_groups:
-            assert g in names
+            assert AdobeGroup.create(g) in mappings[name]['groups']
 
     group_config = [
         {'directory_group': 'Test Group 1', 'sign_group': 'Sign Group 1'},

--- a/user_sync/config/common.py
+++ b/user_sync/config/common.py
@@ -566,3 +566,11 @@ def resolve_invocation_options(options: dict, invocation_config: DictConfig, inv
             continue
         options[k] = arg_val
     return options
+
+
+def as_list(value):
+    if value is None:
+        return []
+    elif isinstance(value, user_sync.port.list_type):
+        return value
+    return [value]

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -29,9 +29,8 @@ def config_schema() -> Schema:
         'user_management': [{
             'directory_group': Or(None, And(str, len)),
             'sign_group': Or(None, And(str, len)),
-            'admin_role': Or(None, [
-                Or(None, 'GROUP_ADMIN', 'ACCOUNT_ADMIN')
-                ]), #TODO: single "source of truth" for these options
+            Optional('group_admin', default=False): Or(bool, None),
+            Optional('account_admin', default=False): Or(bool, None)
         }],
         'logging': {
             'log_to_file': bool,
@@ -112,26 +111,49 @@ class SignConfigLoader(ConfigLoader):
         except SchemaError as e:
             raise ConfigValidationError(e.code) from e
 
-    def get_directory_groups(self) -> Dict[str, AdobeGroup]:
+    def get_directory_groups(self) -> Dict[str, dict]:
         group_mapping = defaultdict(dict)
         group_config = self.main_config.get_list_config('user_management', True)
         if group_config is None:
             return group_mapping
-        for mapping in group_config.iter_dict_configs():
+        for i, mapping in enumerate(group_config.iter_dict_configs()):
             dir_group = mapping.get_string('directory_group')
-            group_mapping[dir_group]['groups'] = []
-            group_mapping[dir_group]['roles'] = []
-            adobe_group = mapping.get_string('sign_group', True)
-            admin_roles = mapping.get_list('admin_role', True)
-            if adobe_group is not None:
-                group = AdobeGroup.create(adobe_group)
+            if dir_group not in group_mapping:
+                # Assign an ordering (priority) for sorting later, since
+                # we cannot depend on defaultdict to preserve order.
+                group_mapping[dir_group]['priority'] = i
+                group_mapping[dir_group]['groups'] = []
+                group_mapping[dir_group]['roles'] = set()
+
+            # Add all roles associated with a directory group
+            # This way, the collection or roles will be applied correctly
+            # instead of only the role associated with one group
+            if mapping.get_bool('group_admin', True):
+                group_mapping[dir_group]['roles'].add('GROUP_ADMIN')
+            if mapping.get_bool('account_admin', True):
+                group_mapping[dir_group]['roles'].add('ACCOUNT_ADMIN')
+
+            sign_group = mapping.get_string('sign_group', True)
+            if sign_group is not None:
+
+                # AdobeGroup will return the same memory instance of a pre-existing group,
+                # so we create it no matter what
+                group = AdobeGroup.create(sign_group)
+                if group is None:
+                    raise AssertionException('Bad Sign group: "{}" in directory group: "{}"'.format(sign_group, dir_group))
                 if group.umapi_name is None:
                     group.umapi_name = self.DEFAULT_ORG_NAME
-            if group is None:
-                raise AssertionException('Bad Sign group: "{}" in directory group: "{}"'.format(adobe_group, dir_group))
-            if group not in group_mapping[dir_group]:
-                group_mapping[dir_group]['groups'].append(group)
-                group_mapping[dir_group]['roles'] = admin_roles
+
+                # Note checking a memory equivalency, not group name
+                # the groups in group_mapping are stored in order of YML file - important
+                # for choosing first match for a user later
+                if group not in group_mapping[dir_group]['groups']:
+                    group_mapping[dir_group]['groups'].append(group)
+
+            # Convert to list for now to maintain compatability
+            for g in group_mapping.values():
+                g['roles'] = list(g['roles'])
+
         return dict(group_mapping)
 
     def get_directory_connector_module_name(self) -> str:

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -28,7 +28,7 @@ def config_schema() -> Schema:
         },
         'user_management': [{
             'directory_group': Or(None, And(str, len)),
-            'sign_group': Or(None, And(str, len)),
+            Optional('sign_group', default=None): Or(None, And(str, len)),
             Optional('group_admin', default=False): Or(bool, None),
             Optional('account_admin', default=False): Or(bool, None)
         }],
@@ -150,9 +150,9 @@ class SignConfigLoader(ConfigLoader):
                 if group not in group_mapping[dir_group]['groups']:
                     group_mapping[dir_group]['groups'].append(group)
 
-            # Convert to list for now to maintain compatability
-            for g in group_mapping.values():
-                g['roles'] = list(g['roles'])
+        # Convert to list for now to maintain compatability
+        for g in group_mapping.values():
+            g['roles'] = list(g['roles'])
 
         return dict(group_mapping)
 

--- a/user_sync/config/user_sync.py
+++ b/user_sync/config/user_sync.py
@@ -34,7 +34,7 @@ from user_sync import flags
 from user_sync.engine import umapi as rules
 from user_sync.engine.common import AdobeGroup, PRIMARY_TARGET_NAME
 from user_sync.error import AssertionException
-from .common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
+from .common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options, as_list
 
 
 class UMAPIConfigLoader(ConfigLoader):
@@ -284,7 +284,7 @@ class UMAPIConfigLoader(ConfigLoader):
                 primary_config_sources.append(item)
             elif isinstance(item, dict):
                 for key, val in six.iteritems(item):
-                    secondary_config_sources[key] = self.as_list(val)
+                    secondary_config_sources[key] = as_list(val)
         primary_config = self.create_umapi_options(primary_config_sources)
         secondary_configs = {key: self.create_umapi_options(val)
                              for key, val in six.iteritems(secondary_config_sources)}
@@ -383,13 +383,6 @@ class UMAPIConfigLoader(ConfigLoader):
                         raise AssertionError("No after_mapping_hook found in extension configuration")
         return options
 
-    @staticmethod
-    def as_list(value):
-        if value is None:
-            return []
-        elif isinstance(value, user_sync.port.list_type):
-            return value
-        return [value]
 
     def get_dict_from_sources(self, sources):
         """


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

**This PR is inherently included in #156, but noted here since it is an update in itself.  If merged here, #156 will shrink.  If merged there in full, this PR need not be merged.**

The goal of this PR is to guarantee that the get_directory_group method process the config correctly in all combinations of roles and groups (including NoneType/absent keys).  The update resolves several logical errors that have gone unnoticed thus far as edge cases or unexpected behaviour.

## Summary
* Get directory group updates to include boolean and absent keys for roles
* Logic corrections to ensure all roles and groups are processed correctly
* Ordering of results preserved by adding priority index for exact matching of users to first match in config

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Unit tests covering possible combinations of groups/roles in the config

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
* Addresses JIRA issues 434, 433, and half of 432 (role mappings in next PR, dependency on this one.