### PR TITLE
changed key to integration_key in connector-sign.yml

### DIFF
--- a/examples/sign/connector-sign.yml
+++ b/examples/sign/connector-sign.yml
@@ -1,5 +1,5 @@
 host: api.echosign.com
-key: [Sign API Key]
+integration_key: [Sign API Key]
 admin_email: user@example.com
 neptune_console: False
 # (optional) You can store credentials in the operating system credential store
@@ -10,4 +10,4 @@ neptune_console: False
 # The actual credential value are placed in the credential store with the
 # username as the admin_email field value, and the key name (perhaps called internet
 # or network address) as the value below.
-#secure_key_key: sign_key
+#secure_integration_key_key: sign_key

--- a/sign_client/client.py
+++ b/sign_client/client.py
@@ -8,13 +8,13 @@ class SignClient:
     version = 'v5'
     _endpoint_template = 'api/rest/{}/'
 
-    def __init__(self, host, key, admin_email, logger=None):
+    def __init__(self, host, integration_key, admin_email, logger=None):
         self.host = host
-        self.key = key
+        self.integration_key = integration_key
         self.admin_email = admin_email
         self.api_url = None
         self.groups = None
-        self.logger = logger or logging.getLogger("sign_client_{}".format(self.key[0:4]))
+        self.logger = logger or logging.getLogger("sign_client_{}".format(self.integration_key[0:4]))
 
     def _init(self):
         self.api_url = self.base_uri()
@@ -32,10 +32,10 @@ class SignClient:
         """
         if self.version == 'v6':
             return {
-                "Authorization": "Bearer {}".format(self.key)
+                "Authorization": "Bearer {}".format(self.integration_key)
             }
         return {
-            "Access-Token": self.key
+            "Access-Token": self.integration_key
         }
 
     def header_json(self):

--- a/tests/fixture/connector-sign.yml
+++ b/tests/fixture/connector-sign.yml
@@ -1,4 +1,4 @@
 host: api.echosignstage.com
-key: "[Sign API Key]"
+integration_key: "[Sign API Key]"
 admin_email: user@example.com
 neptune_console: False

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -106,7 +106,7 @@ def test_target_config_options(sign_config_file, modify_sign_config, tmp_sign_co
     config = SignConfigLoader(args)
     primary_options, _ = config.get_target_options()
     assert primary_options['host'] == 'api.echosignstage.com'
-    assert primary_options['key'] == '[Sign API Key]'
+    assert primary_options['integration_key'] == '[Sign API Key]'
     assert primary_options['admin_email'] == 'user@example.com'
 
     # complex case
@@ -116,7 +116,7 @@ def test_target_config_options(sign_config_file, modify_sign_config, tmp_sign_co
     primary_options, secondary_options = config.get_target_options()
     assert 'org2' in secondary_options
     assert secondary_options['org2']['host'] == 'api.echosignstage.com'
-    assert secondary_options['org2']['key'] == '[Sign API Key]'
+    assert secondary_options['org2']['integration_key'] == '[Sign API Key]'
     assert secondary_options['org2']['admin_email'] == 'user@example.com'
 
     # invalid case

--- a/user_sync/connector/connector_sign.py
+++ b/user_sync/connector/connector_sign.py
@@ -41,13 +41,13 @@ class SignConnector(object):
         self.neptune_console = sign_builder.require_value('neptune_console', bool)
         #sign_builder.set_string_value('console_org', None)
         options = sign_builder.get_options()
-        key = caller_config.get_credential('key', options['admin_email'])
+        integration_key = caller_config.get_credential('integration_key', options['admin_email'])
         self.console_org = org_name
         self.name = 'sign_{}'.format(self.console_org)
         self.logger = logging.getLogger(self.name)
         #caller_config.report_unused_values(self.logger)
         self.sign_client = SignClient(host=options['host'],
-                                      key=key,
+                                      integration_key=integration_key,
                                       admin_email=options['admin_email'],
                                       logger=self.logger)
 


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
*  The error key is  confusing.  The key should be renamed to 'integration_key' to make it more evident where the config is failing.

changed from:
![image](https://user-images.githubusercontent.com/51426161/99090560-68e29780-2594-11eb-9dab-ad6476ab02da.png)
![image](https://user-images.githubusercontent.com/51426161/99090603-75ff8680-2594-11eb-98a1-e3b5c454d785.png)

Changed to:
![image](https://user-images.githubusercontent.com/51426161/99090662-87489300-2594-11eb-926c-04e67040cb84.png)
![image](https://user-images.githubusercontent.com/51426161/99090721-97607280-2594-11eb-8c34-173144c66e31.png)
