### PR TITLE
directory_group_filter bug fix

### DIFF
--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -154,4 +154,17 @@ def test_engine_options(sign_config_file, modify_sign_config, tmp_sign_connector
     assert not (set(SignSyncEngine.default_options.keys()) | set(config.invocation_options.keys())) - set(options.keys())
     assert options['create_users'] == False
     assert options['sign_only_limit'] == 1000
-    
+
+
+def test_load_invocation_options(sign_config_file, modify_sign_config, tmp_sign_connector_config, tmp_config_files):
+    sign_config_file = modify_sign_config(['invocation_defaults'], {'users': 'mapped'})
+    args = {'config_filename': sign_config_file}
+    config = SignConfigLoader(args)
+    options = config.load_invocation_options()
+    assert options['directory_group_mapped'] is True
+    # there is nothing to test if the users option is all, it just means nothing is assigned to directory_group_mapped
+    # and the key doesn't exist until it's assigned, so I can't test for None unless I change the logic
+    # else I get a KeyError
+    # using users: group fails the Schema validation
+    # same for if you leave the field blank or set to None
+    # so as things are written, there's nothing left to test

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -36,10 +36,10 @@ def test_invocation_defaults(modify_sign_config, tmp_sign_connector_config, tmp_
     config = SignConfigLoader(args)
     assert 'users' in config.invocation_options
     assert config.invocation_options['users'] == ['all']
-    args = {'config_filename': sign_config_file, 'users': ['some_option']}
+    args = {'config_filename': sign_config_file, 'users': ['mapped']}
     config = SignConfigLoader(args)
     assert 'users' in config.invocation_options
-    assert config.invocation_options['users'] == ['some_option']
+    assert config.invocation_options['users'] == ['mapped']
 
 
 # NOTE: tmp_sign_connector_config and tmp_config_files are needed to prevent the ConfigFileLoader

--- a/tests/test_sign_config.py
+++ b/tests/test_sign_config.py
@@ -162,9 +162,4 @@ def test_load_invocation_options(sign_config_file, modify_sign_config, tmp_sign_
     config = SignConfigLoader(args)
     options = config.load_invocation_options()
     assert options['directory_group_mapped'] is True
-    # there is nothing to test if the users option is all, it just means nothing is assigned to directory_group_mapped
-    # and the key doesn't exist until it's assigned, so I can't test for None unless I change the logic
-    # else I get a KeyError
-    # using users: group fails the Schema validation
-    # same for if you leave the field blank or set to None
-    # so as things are written, there's nothing left to test
+

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -4,6 +4,8 @@ import codecs
 from copy import deepcopy
 from collections import defaultdict
 from typing import Dict
+
+import six
 from schema import Schema
 
 from user_sync.config.common import DictConfig, ConfigLoader, ConfigFileLoader, resolve_invocation_options
@@ -11,6 +13,7 @@ from user_sync.error import AssertionException
 from user_sync.engine.common import AdobeGroup
 from user_sync.engine.sign import SignSyncEngine
 from .error import ConfigValidationError
+from ..helper import normalize_string
 
 
 def config_schema() -> Schema:
@@ -81,11 +84,28 @@ class SignConfigLoader(ConfigLoader):
         self._validate(self.raw_config)
         self.main_config = self.load_main_config(filename, self.raw_config)
         self.invocation_options = self.load_invocation_options()
+        self.directory_groups = self.load_directory_groups()
     
     def load_invocation_options(self) -> dict:
         options = deepcopy(self.invocation_defaults)
         invocation_config = self.main_config.get_dict_config('invocation_defaults', True)
         options = resolve_invocation_options(options, invocation_config, self.invocation_defaults, self.args)
+        options['directory_connector_type'] = self.main_config.get_dict('identity_source').get('type')
+        # --users
+        users_spec = options.get('users')
+        if users_spec:
+            users_action = normalize_string(users_spec[0])
+            if users_action == 'all':
+                if options['directory_connector_type'] == 'okta':
+                    raise AssertionException('Okta connector module does not support "--users all"')
+            elif users_action == 'mapped':
+                options['directory_group_mapped'] = True
+            elif users_action == 'group':
+                if len(users_spec) != 2:
+                    raise AssertionException('You must specify the groups to read when using the users "group" option')
+                options['directory_group_filter'] = users_spec[1].split(',')
+            else:
+                raise AssertionException('Unknown option "%s" for users' % users_action)
         return options
 
     def load_main_config(self, filename, content) -> DictConfig:
@@ -112,7 +132,10 @@ class SignConfigLoader(ConfigLoader):
         except SchemaError as e:
             raise ConfigValidationError(e.code) from e
 
-    def get_directory_groups(self) -> Dict[str, AdobeGroup]:
+    def get_directory_groups(self):
+        return self.load_directory_groups()
+
+    def load_directory_groups(self) -> Dict[str, AdobeGroup]:
         group_mapping = defaultdict(dict)
         group_config = self.main_config.get_list_config('user_management', True)
         if group_config is None:
@@ -172,6 +195,10 @@ class SignConfigLoader(ConfigLoader):
         options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
         invocation_defaults = self.main_config.get_dict_config('invocation_defaults')
         options['users'] = invocation_defaults.get_string('users')
+        # set the directory group filter from the mapping, if requested.
+        # This must come late, after any prior adds to the mapping from other parameters.
+        if options.get('directory_group_mapped'):
+            options['directory_group_filter'] = set(six.iterkeys(self.directory_groups))
         return options
 
     def check_unused_config_keys(self):

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -15,6 +15,7 @@ class SignSyncEngine:
     default_options = {
         'create_users': False,
         'deactivate_users': False,
+        'directory_group_filter': None,
         'extended_attributes': None,
         'identity_source': {
             'type': 'ldap',
@@ -166,8 +167,7 @@ class SignSyncEngine:
 
             group_id = sign_connector.get_group(assignment_group.lower())
             admin_roles = self.retrieve_admin_role(directory_user)
-            user_roles = self.resolve_new_roles(
-                directory_user, sign_user, admin_roles)
+            user_roles = self.resolve_new_roles(directory_user, sign_user, admin_roles)
             if sign_user is None:
                 # Insert new user if flag is enabled and if Neptune Console
                 if self.options['create_users'] is True and sign_connector.neptune_console is True:
@@ -220,6 +220,10 @@ class SignSyncEngine:
         :param org_name:
         :return:
         """
+        # if using the --users all option, some directory_user dicts may not have a key for sign_groups
+        # if this is the case, they are not a candidate for Sign sync
+        if directory_user.get('sign_groups') is None:
+            return False
         return directory_user['sign_groups']['groups'][0].umapi_name == org_name
 
     def retrieve_assignment_group(self, directory_user):
@@ -254,7 +258,7 @@ class SignSyncEngine:
         self.logger.debug('Building work list...')
 
         options = self.options
-        directory_group_filter = options['users']
+        directory_group_filter = options['directory_group_filter']
         if directory_group_filter is not None:
             directory_group_filter = set(directory_group_filter)
         extended_attributes = options.get('extended_attributes')
@@ -274,9 +278,9 @@ class SignSyncEngine:
                 self.logger.warning(
                     "Ignoring directory user with empty user key: %s", directory_user)
                 continue
-            sign_groups = self.extract_mapped_group(
-                directory_user['groups'], mappings)
-            directory_user['sign_groups'] = sign_groups
+            if directory_group_filter is not None:
+                sign_groups = self.extract_mapped_group(directory_user['groups'], mappings)
+                directory_user['sign_groups'] = sign_groups
             directory_user_by_user_key[user_key] = directory_user
 
     def get_directory_user_key(self, directory_user):

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -167,7 +167,8 @@ class SignSyncEngine:
 
             group_id = sign_connector.get_group(assignment_group.lower())
             admin_roles = self.retrieve_admin_role(directory_user)
-            user_roles = self.resolve_new_roles(directory_user, sign_user, admin_roles)
+            user_roles = self.resolve_new_roles(
+                directory_user, sign_user, admin_roles)
             if sign_user is None:
                 # Insert new user if flag is enabled and if Neptune Console
                 if self.options['create_users'] is True and sign_connector.neptune_console is True:


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
Currently the value for `users` in invocation_defaults will be set to the directorty_group_filter variable in the Sign engine. This results in the letters from that string being made into a set which are interpreted as directory groups. Since the directory groups don't exist, it results in extraneous warning messages. Also, since there was always a value for users, there was always a value for the directory_group_filter, meaning that querying the whole DN (`--users all`) was not possible. This bug fix enables that.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I wrote a new test in test_sign_config.py for the added functionality in the sign config. The test is for the load_invocation_options method. Right now it only tests for the result of using `--users mapped` but there will be more to come.

Note: I had to make a minor fix to the test test_invocation_defaults since it indirectly calls the load_invocation_options method and the dummy value `some_option` throws an AssertionException from that method since it doesn't match any of the supported options.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #xxx
