### PR TITLE
CLI/Config option for --users groups

### DIFF
--- a/examples/sign/connector-sign.yml
+++ b/examples/sign/connector-sign.yml
@@ -1,3 +1,5 @@
+# To fetch below information do login to Sign console then click on Adobe Sign API tab
+# in API information tab click on Integration Key to 'Create integration key' after selecting appropriate 'scope'
 host: api.echosign.com
 key: [Sign API Key]
 admin_email: user@example.com

--- a/tests/test_sign_engine.py
+++ b/tests/test_sign_engine.py
@@ -1,13 +1,13 @@
+import logging
+
 import pytest
 import six
+from mock import MagicMock
 
 from user_sync.config.sign_sync import SignConfigLoader
-from user_sync.connector.directory import DirectoryConnector
-from user_sync.engine.sign import SignSyncEngine
 from user_sync.connector.connector_sign import SignConnector
+from user_sync.engine.sign import SignSyncEngine
 from user_sync.engine.umapi import AdobeGroup
-from mock import patch
-import logging
 
 
 @pytest.fixture
@@ -31,21 +31,20 @@ def directory_user():
                                 'country': 'US'}}}
 
 def test_load_users_and_groups(example_engine, example_user, directory_user):
-    dc = DirectoryConnector
 
-    user = {'directory_user': {'user@example.com': example_user}}
+    dc = MagicMock()
+    example_user['groups'] = ["Sign Users 1"]
+    user =  {'user@example.com': example_user}
 
     def dir_user_replacement(groups, extended_attributes, all_users):
-        return six.itervalues(user)
+        return user.values()
 
     dc.load_users_and_groups = dir_user_replacement
     mapping = {}
-    adobeGroup = AdobeGroup('Group 1', 'primary')
-    adobeGroups = []
-    adobeGroups.append(adobeGroup)
+    adobeGroups = [AdobeGroup('Group 1', 'primary')]
     mapping['Sign Users'] = {'groups': adobeGroups}
     example_engine.read_desired_user_groups(mapping, dc)
-    assert directory_user == user
+    assert example_engine.directory_user_by_user_key == user
 
 
 def test_get_directory_user_key(example_engine, example_user):

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -44,7 +44,8 @@ def config_schema() -> Schema:
             'console_log_level': Or('info', 'debug'), #TODO: what are the valid values here?
         },
         'invocation_defaults': {
-            'users': Or('mapped', 'all'), #TODO: single "source of truth" for these options
+            'users': Or('mapped', 'all', ['group', And(str, len)])
+
             #'directory_group_filter': Or('mapped', 'all', None)
         }
     })
@@ -100,10 +101,17 @@ class SignConfigLoader(ConfigLoader):
                     raise AssertionException('Okta connector module does not support "--users all"')
             elif users_action == 'mapped':
                 options['directory_group_mapped'] = True
+
+
             elif users_action == 'group':
-                if len(users_spec) != 2:
+                if len(users_spec) < 2:
                     raise AssertionException('You must specify the groups to read when using the users "group" option')
-                options['directory_group_filter'] = users_spec[1].split(',')
+                options['directory_group_filter'] = users_spec[1:]
+
+                # if len(users_spec) != 2:
+                #    raise AssertionException('You must specify the groups to read when using the users "group" option')
+                # options['directory_group_filter'] = users_spec[1].split(',')
+
             else:
                 raise AssertionException('Unknown option "%s" for users' % users_action)
         return options
@@ -194,7 +202,7 @@ class SignConfigLoader(ConfigLoader):
         options['deactivate_users'] = user_sync.get_bool('deactivate_users')
         options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
         invocation_defaults = self.main_config.get_dict_config('invocation_defaults')
-        options['users'] = invocation_defaults.get_string('users')
+        options['users'] = invocation_defaults.get_value('users',(str,list))
         # set the directory group filter from the mapping, if requested.
         # This must come late, after any prior adds to the mapping from other parameters.
         if options.get('directory_group_mapped'):

--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -105,12 +105,8 @@ class SignConfigLoader(ConfigLoader):
             elif users_action == 'group':
                 if len(users_spec) < 2:
                     raise AssertionException('You must specify the groups to read when using the users "group" option')
-                options['directory_group_filter'] = users_spec[1:]
-
-                # if len(users_spec) != 2:
-                #    raise AssertionException('You must specify the groups to read when using the users "group" option')
-                # options['directory_group_filter'] = users_spec[1].split(',')
-
+                dgf = users_spec[1].split(',') if len(users_spec) == 2 else users_spec[1:]
+                options['directory_group_filter'] = list({d.strip() for d in dgf})
             else:
                 raise AssertionException('Unknown option "%s" for users' % users_action)
         return options
@@ -200,7 +196,7 @@ class SignConfigLoader(ConfigLoader):
         options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
         invocation_defaults = self.main_config.get_dict_config('invocation_defaults', True)
         if invocation_defaults is not None:
-        options['users'] = invocation_defaults.get_value('users',(str,list))
+            options['users'] = invocation_defaults.get_value('users',(str,list))
         # set the directory group filter from the mapping, if requested.
         # This must come late, after any prior adds to the mapping from other parameters.
         if options.get('directory_group_mapped'):

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -271,6 +271,9 @@ class SignSyncEngine:
                                                                     all_users=directory_group_filter is None)
 
         for directory_user in directory_users:
+            if not self.is_directory_user_in_groups(directory_user, directory_group_filter):
+                continue
+
             user_key = self.get_directory_user_key(directory_user)
             if not user_key:
                 self.logger.warning(
@@ -280,6 +283,19 @@ class SignSyncEngine:
                 sign_groups = self.extract_mapped_group(directory_user['groups'], mappings)
                 directory_user['sign_groups'] = sign_groups
             directory_user_by_user_key[user_key] = directory_user
+
+    def is_directory_user_in_groups(self, directory_user, groups):
+        """
+        :type directory_user: dict
+        :type groups: set
+        :rtype bool
+        """
+        if groups is None:
+            return True
+        for directory_user_group in directory_user['groups']:
+            if directory_user_group in groups:
+                return True
+        return False
 
     def get_directory_user_key(self, directory_user):
         """


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Modified schema to support -- group ['group1','group2']
* Modified load_invocation_options to handle -- group type
* Added new comments on connector-sign.yml file.
<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* on file add respective groups 
ex:-
 invocation_defaults:
      users: ['group','SignGroupOne','SignGroupTwo']
and run Sign_sync with below parameter
sign-sync -c ../var/basicsync/sign-sync-config.yml
it should read  all users in respective groups and sync them into sign console.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->

Fixes #163 #164 
