### PR TITLE
Make invocation_defaults key optional in sign-sync-config.yml

### DIFF
--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -43,7 +43,7 @@ def config_schema() -> Schema:
             'file_log_level': Or('info', 'debug'), #TODO: what are the valid values here?
             'console_log_level': Or('info', 'debug'), #TODO: what are the valid values here?
         },
-        'invocation_defaults': {
+        Optional('invocation_defaults'): {
             'users': Or('mapped', 'all'), #TODO: single "source of truth" for these options
             #'directory_group_filter': Or('mapped', 'all', None)
         }
@@ -193,8 +193,9 @@ class SignConfigLoader(ConfigLoader):
         options['create_users'] = user_sync.get_bool('create_users')
         options['deactivate_users'] = user_sync.get_bool('deactivate_users')
         options['sign_only_limit'] = user_sync.get_value('sign_only_limit', (int, str))
-        invocation_defaults = self.main_config.get_dict_config('invocation_defaults')
-        options['users'] = invocation_defaults.get_string('users')
+        invocation_defaults = self.main_config.get_dict_config('invocation_defaults', True)
+        if invocation_defaults is not None:
+            options['users'] = invocation_defaults.get_string('users')
         # set the directory group filter from the mapping, if requested.
         # This must come late, after any prior adds to the mapping from other parameters.
         if options.get('directory_group_mapped'):


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
I altered the config schema for Sign to make the invocation_defaults key optional. This allows the user to comment out that section of the config and still allow the tool to run. The invocation defaults in this case would be the default values given in the init functions.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
No additional tests were written for this story.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #xxx
