### PR TITLE
Add config options to remove roles and remove groups for sign-only users

### DIFF
--- a/tests/test_sign_engine.py
+++ b/tests/test_sign_engine.py
@@ -48,6 +48,7 @@ def test_handle_sign_only_users(example_engine):
         'firstName': 'User',
         'lastName': 'Last',
         'group': 'Group 1',
+        'groupId': 'group1Id',
         'roles': ['GROUP_ADMIN'],
         'userId': 'erewcwererc',
     }
@@ -69,6 +70,21 @@ def test_handle_sign_only_users(example_engine):
                                                         'groupId': 'somerandomGROUPID', 'lastName': 'Last',
                                                         'roles': ['NORMAL_USER']})
 
+    # Check remove_roles (group should remain the same as it is for ex_sign_user)
+    example_engine.options['user_sync']['sign_only_user_action'] = 'remove_roles'
+    example_engine.handle_sign_only_users(sign_connector, 'primary', 'somerandomGROUPID')
+    assert sign_connector.update_user.call_args[0] == ('erewcwererc',
+                                                       {'email': 'example.user@signtest.com', 'firstName': 'User',
+                                                        'groupId': 'group1Id', 'lastName': 'Last',
+                                                        'roles': ['NORMAL_USER']})
+
+    # Check remove_groups (role should remain the same as it is for ex_sign_user)
+    example_engine.options['user_sync']['sign_only_user_action'] = 'remove_groups'
+    example_engine.handle_sign_only_users(sign_connector, 'primary', 'somerandomGROUPID')
+    assert sign_connector.update_user.call_args[0] == ('erewcwererc',
+                                                       {'email': 'example.user@signtest.com', 'firstName': 'User',
+                                                        'groupId': 'somerandomGROUPID', 'lastName': 'Last',
+                                                        'roles': ['GROUP_ADMIN']})
 
 def test_roles_match():
     resolved_role = ['GROUP_ADMIN', 'ACCOUNT_ADMIN']

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -429,6 +429,11 @@ class SignSyncEngine:
                 sign_connector.update_user(sign_user['userId'], reset_data)
                 self.logger.info("{}Reset Sign user '{}', to normal user role".format(
                     self.org_string(org_name), sign_user['email']))
+            if sign_only_user_action == 'remove_groups':
+                reset_data['roles'] = sign_user['roles']
+                sign_connector.update_user(sign_user['userId'], reset_data)
+                self.logger.info("{}Reset Sign user '{}', to default group".format(
+                    self.org_string(org_name), sign_user['email']))
 
     def check_sign_max_limit(self, org_name):
         stray_count = len(self.sign_only_users_by_org[org_name])

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -416,20 +416,21 @@ class SignSyncEngine:
                 "lastName": sign_user['lastName'],
                 "roles": ['NORMAL_USER']
             }
+            user_in_default_group = sign_user['group'].lower() == self.DEFAULT_GROUP_NAME.lower()
+            is_normal_user = sign_user['roles'] == ['NORMAL_USER']
+            if user_in_default_group and is_normal_user:
+                continue
             if sign_only_user_action == 'reset':
-                if (sign_user['group'].lower() == self.DEFAULT_GROUP_NAME.lower()
-                        and sign_user['roles'] == ['NORMAL_USER']):
-                    continue
                 sign_connector.update_user(
                     sign_user['userId'], reset_data)
                 self.logger.info("{}Reset Sign user '{}', to default group and normal user role".format(
                     self.org_string(org_name), sign_user['email']))
-            if sign_only_user_action == 'remove_roles':
+            if sign_only_user_action == 'remove_roles' and not is_normal_user:
                 reset_data['groupId'] = sign_user['groupId']
                 sign_connector.update_user(sign_user['userId'], reset_data)
                 self.logger.info("{}Reset Sign user '{}', to normal user role".format(
                     self.org_string(org_name), sign_user['email']))
-            if sign_only_user_action == 'remove_groups':
+            if sign_only_user_action == 'remove_groups' and not user_in_default_group:
                 reset_data['roles'] = sign_user['roles']
                 sign_connector.update_user(sign_user['userId'], reset_data)
                 self.logger.info("{}Reset Sign user '{}', to default group".format(

--- a/user_sync/engine/sign.py
+++ b/user_sync/engine/sign.py
@@ -409,20 +409,25 @@ class SignSyncEngine:
                 except AssertionException as e:
                     self.logger.error("Error deactivating user {}, {}".format(sign_user['email'], e))
                     continue
+            reset_data = {
+                "email": sign_user['email'],
+                "firstName": sign_user['firstName'],
+                "groupId": default_group_id,
+                "lastName": sign_user['lastName'],
+                "roles": ['NORMAL_USER']
+            }
             if sign_only_user_action == 'reset':
                 if (sign_user['group'].lower() == self.DEFAULT_GROUP_NAME.lower()
                         and sign_user['roles'] == ['NORMAL_USER']):
                     continue
-                reset_data = {
-                    "email": sign_user['email'],
-                    "firstName": sign_user['firstName'],
-                    "groupId": default_group_id,
-                    "lastName": sign_user['lastName'],
-                    "roles": ['NORMAL_USER']
-                }
                 sign_connector.update_user(
                     sign_user['userId'], reset_data)
                 self.logger.info("{}Reset Sign user '{}', to default group and normal user role".format(
+                    self.org_string(org_name), sign_user['email']))
+            if sign_only_user_action == 'remove_roles':
+                reset_data['groupId'] = sign_user['groupId']
+                sign_connector.update_user(sign_user['userId'], reset_data)
+                self.logger.info("{}Reset Sign user '{}', to normal user role".format(
                     self.org_string(org_name), sign_user['email']))
 
     def check_sign_max_limit(self, org_name):


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
This PR adds two additional configuration options that control how the sync handles sign-only-users. `remove_roles` will keep sign only users in their current group, but demote them to `NORMAL_USR` if applicable. `remove_groups` will remove sign only users from their groups (placing them in default group) while maintaining their current admin level.

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
I added two assertions to the existing test for the handle sign only users method that cover both options. I had to add one key to the example sign user dictionary for `group_id` in order to correctly mirror the logic in the method. The sign user being acted upon in the method has both a group and group_id attribute whereas the example for the test had only group.

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #xxx
