### PR TITLE
Error handling for missing config files in sign_phase 2

### DIFF
--- a/user_sync/app.py
+++ b/user_sync/app.py
@@ -180,8 +180,12 @@ def sync(**kwargs):
     # sign_config_file = kwargs.get('sign_sync_config')
     # if 'sign_sync_config' in kwargs:
     #     del (kwargs['sign_sync_config'])
-    run_sync(config.UMAPIConfigLoader(kwargs), begin_work_umapi)
-
+    try:
+        run_sync(config.UMAPIConfigLoader(kwargs), begin_work_umapi)
+    except AssertionException as e:
+        if not e.is_reported():
+            logger.critical("%s", e)
+            e.set_reported()
 
 @main.command()
 @click.help_option('-h', '--help')
@@ -207,7 +211,10 @@ def sign_sync(**kwargs):
         run_sync(SignConfigLoader(kwargs), begin_work_sign)
     except ConfigValidationError as e:
         logger.critical('Schema validation failed. Detailed message: {}'.format(e))
-
+    except AssertionException as e:
+        if not e.is_reported():
+            logger.critical("%s", e)
+            e.set_reported()
 
 @main.command()
 @click.help_option('-h', '--help')


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
* Edited error handling for missing main config files: user-sync.config.yml and sign-sync-config.yml. When the config files were missing the error was not being handled by logger, but instead a stack trace.
* Errors are now being handled by critical logger: 
* 
![image](https://user-images.githubusercontent.com/51426161/141857440-72cc25ae-2c9d-4afc-b67b-678722702da2.png)

![image](https://user-images.githubusercontent.com/51426161/141857481-52701620-cb06-47b9-afe6-83acff074711.png)


<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Completed manual testing with missing config files in sign-sync-config and user-sync-config.yml and check for appropriate error handling. 

<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->
Fixes #205 
