### PR TITLE
Require "primary" key in sign_orgs config

### DIFF
--- a/user_sync/config/sign_sync.py
+++ b/user_sync/config/sign_sync.py
@@ -207,10 +207,11 @@ class SignConfigLoader(ConfigLoader):
         source_config_path = identity_config['connector']
         return self.config_loader.load_sub_config(source_config_path)
 
-    def get_target_options(self) -> dict[str, dict]:
+    def get_target_options(self) -> tuple[dict, dict]:
         target_configs = self.main_config.get_dict('sign_orgs')
         if self.DEFAULT_ORG_NAME not in target_configs:
-            raise AssertionException(f"'sign_orgs' config must specify a connector with '{self.DEFAULT_ORG_NAME}' key")
+            raise AssertionException(
+                f"'sign_orgs' config must specify a connector with '{self.DEFAULT_ORG_NAME}' key")
         primary_options = self.config_loader.load_sub_config(target_configs[self.DEFAULT_ORG_NAME])
         all_options = {}
         for target_id, config_file in target_configs.items():
@@ -226,6 +227,7 @@ class SignConfigLoader(ConfigLoader):
 
         sign_orgs = self.main_config.get_dict('sign_orgs')
         options['sign_orgs'] = sign_orgs
+        self.get_target_options()
         user_sync = self.main_config.get_dict_config('user_sync')
         max_missing = user_sync.get_value('sign_only_limit', (int, str))
         options['user_sync']['sign_only_limit'] = validate_max_limit_config(max_missing)


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
*The key "primary" under "sign_orgs" is required to identify the primary Sign connection. Additional connection IDs can be named anything except "primary". An error should be thrown if the primary connector key is not named "primary". The following error is now displayed if anything but "primary" is used for the key: 
![image](https://user-images.githubusercontent.com/51426161/142050573-24ee8d0f-ca49-4e0b-9de3-2e197d94709f.png)


<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
* Manual testing of changing sign orgs 'primary' key value, when using multiple connectors or using only one connector.
<!-- REQUIRED: Link to all bugs that this PR fixes, one link per line -->
<!-- If there is no related issue, please create one and link it here before submitting the PR -->

Fixes #208 
